### PR TITLE
build: add project.json to api and website

### DIFF
--- a/api/project.json
+++ b/api/project.json
@@ -1,0 +1,14 @@
+{
+  "root": "api",
+  "targets": {
+    "dev": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "dev"
+      },
+      "dependsOn": [
+        "^dev"
+      ]
+    }
+  }
+}

--- a/website/project.json
+++ b/website/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "website",
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build"
+      },
+      "dependsOn": [
+        "^build"
+      ]
+    },
+    "dev": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "dev"
+      },
+      "dependsOn": [
+        "^build"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
declare targets dependencies in the project.json, now we can start the website dev server with `nx run-many --target=dev --all` without any errors

![image](https://user-images.githubusercontent.com/13861843/181452146-45906528-d86d-4ce7-ba27-99f5b4243e61.png)
