### PR TITLE
Added support for API Key authentication

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node -r ts-node/register -r tsconfig-paths/register --inspect -r dotenv/config src/server.ts",
     "typeorm": "typeorm-ts-node-esm",
+    "migration:create": "npx typeorm-ts-node-esm migration:create",
     "migration:run": "npx typeorm-ts-node-esm migration:run -d src/data_sources/dashboard.ts",
     "migration:revert": "npx typeorm-ts-node-esm migration:revert -d src/data_sources/dashboard.ts",
     "build": "gulp build",

--- a/api/package.json
+++ b/api/package.json
@@ -26,6 +26,7 @@
     "crypto-js": "^4.1.1",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
+    "generate-api-key": "^1.0.2",
     "inversify": "^6.0.1",
     "inversify-express-utils": "^6.4.3",
     "jsonwebtoken": "^8.5.1",

--- a/api/src/api_models/api.ts
+++ b/api/src/api_models/api.ts
@@ -1,0 +1,173 @@
+import { Type } from "class-transformer";
+import { IsIn, IsInt, IsOptional, IsString, IsUUID, Length, ValidateNested } from "class-validator";
+import { ApiModel, ApiModelProperty } from "swagger-express-ts";
+import { FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from "./base";
+import { ROLE_TYPES } from "./role";
+
+@ApiModel({
+  description: 'ApiKey entity',
+  name: 'ApiKey',
+})
+export class ApiKey {
+  @ApiModelProperty({
+    description: 'ApiKey ID in uuid format',
+    required: false,
+  })
+  id: string;
+
+  @ApiModelProperty({
+    description: 'Name of the ApiKey',
+    required: true,
+  })
+  name: string;
+
+  @ApiModelProperty({
+    description: 'ApiKey role ID',
+    required: true,
+  })
+  role_id: number;
+
+  @ApiModelProperty({
+    description: 'Domain of the ApiKey',
+    required: true,
+  })
+  domain: string;
+}
+
+@ApiModel({
+  description: 'ApiKey filter object',
+  name: 'ApiKeyFilterObject',
+})
+export class ApiKeyFilterObject implements FilterRequest {
+  @IsOptional()
+  @ApiModelProperty({
+    description: 'search term. Uses fuzzy search for name and domain',
+    required: false,
+  })
+  search?: string;
+}
+
+@ApiModel({
+  description: 'ApiKey sort object',
+  name: 'ApiKeySortObject'
+})
+export class ApiKeySortObject implements SortRequest {
+  @IsIn(['name', 'domain', 'create_time'])
+  @ApiModelProperty({
+    description: 'Field for sorting',
+    required: true,
+    enum: ['name', 'domain', 'create_time'],
+  })
+  field: 'name' | 'domain' | 'create_time';
+
+  @IsIn(['ASC', 'DESC'])
+  @ApiModelProperty({
+    description: 'Sort order',
+    required: true,
+    enum: ['ASC', 'DESC'],
+  })
+  order: 'ASC' | 'DESC';
+
+  constructor(data: any) {
+    Object.assign(this, data);
+  }
+}
+
+@ApiModel({
+  description: 'ApiKey list request object',
+  name: 'ApiKeyListRequest',
+})
+export class ApiKeyListRequest {
+  @IsOptional()
+  @Type(() => ApiKeyFilterObject)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'ApiKey filter object',
+    required: false,
+    model: 'ApiKeyFilterObject',
+  })
+  filter?: ApiKeyFilterObject;
+
+  @Type(() => ApiKeySortObject)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'ApiKey sort object',
+    required: true,
+    model: 'ApiKeySortObject',
+  })
+  sort: ApiKeySortObject = new ApiKeySortObject({ field: 'create_time', order: 'ASC' });
+
+  @Type(() => PaginationRequest)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'Pagination object',
+    required: true,
+    model: 'PaginationRequest',
+  })
+  pagination: PaginationRequest = new PaginationRequest({ page: 1, pagesize: 20 });
+}
+
+@ApiModel({
+  description: 'ApiKey pagination response object',
+  name: 'ApiKeyPaginationResponse',
+})
+export class ApiKeyPaginationResponse implements PaginationResponse<ApiKey> {
+  @ApiModelProperty({
+    description: 'Total number results',
+  })
+  total: number;
+
+  @ApiModelProperty({
+    description: 'Current offset of results',
+  })
+  offset: number;
+
+  @ApiModelProperty({
+    description: 'ApiKeys',
+    model: 'ApiKey',
+  })
+  data: ApiKey[];
+}
+
+@ApiModel({
+  description: 'ApiKey create request object',
+  name: 'ApiKeyCreateRequest',
+})
+export class ApiKeyCreateRequest {
+  @IsString()
+  @Length(1, 100)
+  @ApiModelProperty({
+    description: 'ApiKey name',
+    required: true,
+  })
+  name: string;
+
+  @IsString()
+  @ApiModelProperty({
+    description: 'Domain of the ApiKey',
+    required: true,
+  })
+  domain: string;
+
+  @IsInt()
+  @IsIn([ROLE_TYPES.INACTIVE, ROLE_TYPES.READER, ROLE_TYPES.AUTHOR, ROLE_TYPES.ADMIN])
+  @ApiModelProperty({
+    description: 'ApiKey role ID',
+    required: true,
+    enum: [ROLE_TYPES.INACTIVE.toString(), ROLE_TYPES.READER.toString(), ROLE_TYPES.AUTHOR.toString(), ROLE_TYPES.ADMIN.toString()],
+  })
+  role_id: ROLE_TYPES.INACTIVE | ROLE_TYPES.READER | ROLE_TYPES.AUTHOR | ROLE_TYPES.ADMIN;
+}
+
+@ApiModel({
+  description: 'ApiKey ID request',
+  name: 'ApiKeyIDRequest',
+})
+export class ApiKeyIDRequest {
+  @IsUUID()
+  @ApiModelProperty({
+    description: 'ApiKey uuid',
+    required: true,
+  })
+  id: string;
+}

--- a/api/src/api_models/api.ts
+++ b/api/src/api_models/api.ts
@@ -1,8 +1,8 @@
-import { Type } from "class-transformer";
-import { IsIn, IsInt, IsOptional, IsString, IsUUID, Length, ValidateNested } from "class-validator";
-import { ApiModel, ApiModelProperty } from "swagger-express-ts";
-import { FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from "./base";
-import { ROLE_TYPES } from "./role";
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, IsUUID, Length, ValidateNested } from 'class-validator';
+import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
+import { FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { ROLE_TYPES } from './role';
 
 @ApiModel({
   description: 'ApiKey entity',

--- a/api/src/api_models/index.ts
+++ b/api/src/api_models/index.ts
@@ -10,6 +10,7 @@ import {
   Account, AccountLoginRequest, AccountLoginResponse, AccountFilterObject, AccountSortObject, AccountListRequest, AccountPaginationResponse,
   AccountCreateRequest, AccountUpdateRequest, AccountEditRequest, AccountChangePasswordRequest, AccountIDRequest,
 } from './account';
+import { ApiKey, ApiKeyCreateRequest, ApiKeyListRequest, ApiKeyFilterObject, ApiKeyPaginationResponse, ApiKeySortObject, ApiKeyIDRequest } from './api';
 import { Role } from './role';
 import { QueryRequest, HttpParams } from './query';
 import { ApiError } from './base';
@@ -47,6 +48,14 @@ export default {
   AccountEditRequest,
   AccountChangePasswordRequest,
   AccountIDRequest,
+
+  ApiKey,
+  ApiKeyCreateRequest,
+  ApiKeyListRequest,
+  ApiKeyFilterObject,
+  ApiKeyPaginationResponse,
+  ApiKeySortObject,
+  ApiKeyIDRequest,
 
   Role,
 

--- a/api/src/controller/api.controller.ts
+++ b/api/src/controller/api.controller.ts
@@ -1,0 +1,107 @@
+import * as express from 'express';
+import _ from 'lodash';
+import { inject, interfaces as inverfaces } from 'inversify';
+import { controller, httpPost, interfaces } from 'inversify-express-utils';
+import { ApiOperationPost, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
+import { validate } from '../middleware/validation';
+import { RoleService } from '../services/role.service';
+import Account from '../models/account';
+import { ROLE_TYPES } from '../api_models/role';
+import { ApiService } from '../services/api.service';
+import { checkControllerActive } from '../utils/helpers';
+import { ApiKeyCreateRequest, ApiKeyIDRequest, ApiKeyListRequest } from '../api_models/api';
+import ApiKey from '../models/apiKey';
+
+@ApiPath({
+  path: '/api',
+  name: 'API'
+})
+@controller('/api')
+export class APIController implements interfaces.Controller {
+  public static TARGET_NAME = 'API';
+  private apiService: ApiService;
+  private roleService: RoleService;
+  
+  public constructor(
+    @inject('Newable<ApiService>') ApiService: inverfaces.Newable<ApiService>,
+    @inject('Newable<RoleService>') RoleService: inverfaces.Newable<RoleService>
+  ) {
+    this.apiService = new ApiService();
+    this.roleService = new RoleService();
+  }
+
+  @ApiOperationPost({
+    path: '/key/list',
+    description: 'List apikeys. Only admins can view',
+    parameters: {
+      body: { description: 'apikey list request', required: true, model: 'ApiKeyListRequest' }
+    },
+    responses: {
+      200: { description: 'SUCCESS', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiKeyPaginationResponse' },
+      500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
+    }
+  })
+  @httpPost('/key/list')
+  public async listKeys(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
+    try {
+      checkControllerActive();
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
+      const { filter, sort, pagination } = validate(ApiKeyListRequest, req.body);
+      const result = await this.apiService.listKeys(filter, sort, pagination);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  @ApiOperationPost({
+    path: '/key/create',
+    description: 'create a new apikey',
+    parameters: {
+      body: { description: 'new apikey request', required: true, model: 'ApiKeyCreateRequest' }
+    },
+    responses: {
+      200: { description: 'SUCCESS', type: SwaggerDefinitionConstant.Response.Type.STRING },
+      500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
+    }
+  })
+  @httpPost('/key/create')
+  public async createKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
+    try {
+      checkControllerActive();
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
+      const { name, domain, role_id } = validate(ApiKeyCreateRequest, req.body);
+      const result = await this.apiService.createKey(name, domain, role_id);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  @ApiOperationPost({
+    path: '/key/delete',
+    description: 'Delete apikey',
+    parameters: {
+      body: { description: 'delete apikey', required: true, model: 'ApiKeyIDRequest' }
+    },
+    responses: {
+      200: { description: 'SUCCESS', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiKeyIDRequest' },
+      500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
+    }
+  })
+  @httpPost('/key/delete')
+  public async deleteKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
+    try {
+      checkControllerActive();
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
+      const { id } = validate(ApiKeyIDRequest, req.body);
+      await this.apiService.deleteKey(id);
+      res.json({ id });
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/api/src/controller/api.controller.ts
+++ b/api/src/controller/api.controller.ts
@@ -6,9 +6,9 @@ import { ApiOperationPost, ApiPath, SwaggerDefinitionConstant } from 'swagger-ex
 import { validate } from '../middleware/validation';
 import { ROLE_TYPES } from '../api_models/role';
 import { ApiService } from '../services/api.service';
-import { checkControllerActive } from '../utils/helpers';
 import { ApiKeyCreateRequest, ApiKeyIDRequest, ApiKeyListRequest } from '../api_models/api';
 import permission from '../middleware/permission';
+import ensureAuthEnabled from '../middleware/ensureAuthEnabled';
 
 @ApiPath({
   path: '/api',
@@ -36,10 +36,9 @@ export class APIController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpPost('/key/list', permission(ROLE_TYPES.ADMIN))
+  @httpPost('/key/list', ensureAuthEnabled, permission(ROLE_TYPES.ADMIN))
   public async listKeys(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      checkControllerActive();
       const { filter, sort, pagination } = validate(ApiKeyListRequest, req.body);
       const result = await this.apiService.listKeys(filter, sort, pagination);
       res.json(result);
@@ -59,10 +58,9 @@ export class APIController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpPost('/key/create', permission(ROLE_TYPES.ADMIN))
+  @httpPost('/key/create', ensureAuthEnabled, permission(ROLE_TYPES.ADMIN))
   public async createKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      checkControllerActive();
       const { name, domain, role_id } = validate(ApiKeyCreateRequest, req.body);
       const result = await this.apiService.createKey(name, domain, role_id);
       res.json(result);
@@ -82,10 +80,9 @@ export class APIController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpPost('/key/delete', permission(ROLE_TYPES.ADMIN))
+  @httpPost('/key/delete', ensureAuthEnabled, permission(ROLE_TYPES.ADMIN))
   public async deleteKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      checkControllerActive();
       const { id } = validate(ApiKeyIDRequest, req.body);
       await this.apiService.deleteKey(id);
       res.json({ id });

--- a/api/src/controller/api.controller.ts
+++ b/api/src/controller/api.controller.ts
@@ -4,13 +4,11 @@ import { inject, interfaces as inverfaces } from 'inversify';
 import { controller, httpPost, interfaces } from 'inversify-express-utils';
 import { ApiOperationPost, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
 import { validate } from '../middleware/validation';
-import { RoleService } from '../services/role.service';
-import Account from '../models/account';
 import { ROLE_TYPES } from '../api_models/role';
 import { ApiService } from '../services/api.service';
 import { checkControllerActive } from '../utils/helpers';
 import { ApiKeyCreateRequest, ApiKeyIDRequest, ApiKeyListRequest } from '../api_models/api';
-import ApiKey from '../models/apiKey';
+import permission from '../middleware/permission';
 
 @ApiPath({
   path: '/api',
@@ -20,14 +18,11 @@ import ApiKey from '../models/apiKey';
 export class APIController implements interfaces.Controller {
   public static TARGET_NAME = 'API';
   private apiService: ApiService;
-  private roleService: RoleService;
   
   public constructor(
-    @inject('Newable<ApiService>') ApiService: inverfaces.Newable<ApiService>,
-    @inject('Newable<RoleService>') RoleService: inverfaces.Newable<RoleService>
+    @inject('Newable<ApiService>') ApiService: inverfaces.Newable<ApiService>
   ) {
     this.apiService = new ApiService();
-    this.roleService = new RoleService();
   }
 
   @ApiOperationPost({
@@ -41,12 +36,10 @@ export class APIController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpPost('/key/list')
+  @httpPost('/key/list', permission(ROLE_TYPES.ADMIN))
   public async listKeys(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
       checkControllerActive();
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
       const { filter, sort, pagination } = validate(ApiKeyListRequest, req.body);
       const result = await this.apiService.listKeys(filter, sort, pagination);
       res.json(result);
@@ -66,12 +59,10 @@ export class APIController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpPost('/key/create')
+  @httpPost('/key/create', permission(ROLE_TYPES.ADMIN))
   public async createKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
       checkControllerActive();
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
       const { name, domain, role_id } = validate(ApiKeyCreateRequest, req.body);
       const result = await this.apiService.createKey(name, domain, role_id);
       res.json(result);
@@ -91,12 +82,10 @@ export class APIController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpPost('/key/delete')
+  @httpPost('/key/delete', permission(ROLE_TYPES.ADMIN))
   public async deleteKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
       checkControllerActive();
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
       const { id } = validate(ApiKeyIDRequest, req.body);
       await this.apiService.deleteKey(id);
       res.json({ id });

--- a/api/src/controller/dashboard.controller.ts
+++ b/api/src/controller/dashboard.controller.ts
@@ -5,10 +5,8 @@ import { ApiOperationGet, ApiOperationPost, ApiOperationPut, ApiPath, SwaggerDef
 import { DashboardService } from '../services/dashboard.service';
 import { validate } from '../middleware/validation';
 import { DashboardListRequest, DashboardCreateRequest, DashboardUpdateRequest, DashboardIDRequest } from '../api_models/dashboard';
-import { RoleService } from '../services/role.service';
-import Account from '../models/account';
 import { ROLE_TYPES } from '../api_models/role';
-import ApiKey from '../models/apiKey';
+import permission from '../middleware/permission';
 
 @ApiPath({
   path: '/dashboard',
@@ -18,14 +16,11 @@ import ApiKey from '../models/apiKey';
 export class DashboardController implements interfaces.Controller {
   public static TARGET_NAME = 'Dashboard';
   private dashboardService: DashboardService;
-  private roleService: RoleService;
 
   public constructor(
-    @inject('Newable<DashboardService>') DashboardService: inverfaces.Newable<DashboardService>,
-    @inject('Newable<RoleService>') RoleService: inverfaces.Newable<RoleService>
+    @inject('Newable<DashboardService>') DashboardService: inverfaces.Newable<DashboardService>
   ) {
     this.dashboardService = new DashboardService();
-    this.roleService = new RoleService();
   }
 
   @ApiOperationPost({
@@ -39,11 +34,9 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpPost('/list')
+  @httpPost('/list', permission(ROLE_TYPES.READER))
   public async list(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const { filter, sort, pagination } = validate(DashboardListRequest, req.body);
       const result = await this.dashboardService.list(filter, sort, pagination);
       res.json(result);
@@ -63,11 +56,9 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpPost('/create')
+  @httpPost('/create', permission(ROLE_TYPES.AUTHOR))
   public async create(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.AUTHOR);
       const { name, content } = validate(DashboardCreateRequest, req.body);
       const result = await this.dashboardService.create(name, content);
       res.json(result);
@@ -88,11 +79,9 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpGet('/details/:id')
+  @httpGet('/details/:id', permission(ROLE_TYPES.READER))
   public async details(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const id = req.params.id;
       const result = await this.dashboardService.get(id);
       res.json(result);
@@ -113,11 +102,9 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpPut('/update')
+  @httpPut('/update', permission(ROLE_TYPES.AUTHOR))
   public async update(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.AUTHOR);
       const { id, name, content, is_removed } = validate(DashboardUpdateRequest, req.body);
       const result = await this.dashboardService.update(id, name, content, is_removed);
       res.json(result);
@@ -138,11 +125,9 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpPost('/delete')
+  @httpPost('/delete', permission(ROLE_TYPES.AUTHOR))
   public async delete(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.AUTHOR);
       const { id } = validate(DashboardIDRequest, req.body);
       const result = await this.dashboardService.delete(id);
       res.json(result);

--- a/api/src/controller/dashboard.controller.ts
+++ b/api/src/controller/dashboard.controller.ts
@@ -8,6 +8,7 @@ import { DashboardListRequest, DashboardCreateRequest, DashboardUpdateRequest, D
 import { RoleService } from '../services/role.service';
 import Account from '../models/account';
 import { ROLE_TYPES } from '../api_models/role';
+import ApiKey from '../models/apiKey';
 
 @ApiPath({
   path: '/dashboard',
@@ -41,8 +42,8 @@ export class DashboardController implements interfaces.Controller {
   @httpPost('/list')
   public async list(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.READER);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const { filter, sort, pagination } = validate(DashboardListRequest, req.body);
       const result = await this.dashboardService.list(filter, sort, pagination);
       res.json(result);
@@ -65,8 +66,8 @@ export class DashboardController implements interfaces.Controller {
   @httpPost('/create')
   public async create(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.AUTHOR);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.AUTHOR);
       const { name, content } = validate(DashboardCreateRequest, req.body);
       const result = await this.dashboardService.create(name, content);
       res.json(result);
@@ -90,8 +91,8 @@ export class DashboardController implements interfaces.Controller {
   @httpGet('/details/:id')
   public async details(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.READER);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const id = req.params.id;
       const result = await this.dashboardService.get(id);
       res.json(result);
@@ -115,8 +116,8 @@ export class DashboardController implements interfaces.Controller {
   @httpPut('/update')
   public async update(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.AUTHOR);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.AUTHOR);
       const { id, name, content, is_removed } = validate(DashboardUpdateRequest, req.body);
       const result = await this.dashboardService.update(id, name, content, is_removed);
       res.json(result);
@@ -140,8 +141,8 @@ export class DashboardController implements interfaces.Controller {
   @httpPost('/delete')
   public async delete(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.AUTHOR);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.AUTHOR);
       const { id } = validate(DashboardIDRequest, req.body);
       const result = await this.dashboardService.delete(id);
       res.json(result);

--- a/api/src/controller/datasource.controller.ts
+++ b/api/src/controller/datasource.controller.ts
@@ -10,6 +10,7 @@ import { RoleService } from '../services/role.service';
 import Account from '../models/account';
 import { ROLE_TYPES } from '../api_models/role';
 import { ApiError, BAD_REQUEST } from '../utils/errors';
+import ApiKey from '../models/apiKey';
 
 @ApiPath({
   path: '/datasource',
@@ -43,8 +44,8 @@ export class DataSourceController implements interfaces.Controller {
   @httpPost('/list')
   public async list(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.READER);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const { filter, sort, pagination } = validate(DataSourceListRequest, req.body);
       const result = await this.dataSourceService.list(filter, sort, pagination);
       res.json(result);
@@ -67,8 +68,8 @@ export class DataSourceController implements interfaces.Controller {
   @httpPost('/create')
   public async create(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.ADMIN);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
       // eslint-disable-next-line prefer-const
       let {type, key, config } = validate(DataSourceCreateRequest, req.body);
       config = this.validateConfig(type, config);
@@ -93,8 +94,8 @@ export class DataSourceController implements interfaces.Controller {
   @httpPost('/delete')
   public async delete(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.ADMIN);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.ADMIN);
       const { id } = validate(DataSourceIDRequest, req.body);
       await this.dataSourceService.delete(id);
       res.json();

--- a/api/src/controller/index.ts
+++ b/api/src/controller/index.ts
@@ -5,6 +5,7 @@ import { QueryController } from './query.controller';
 import { DataSourceController } from './datasource.controller';
 import { AccountController } from './account.controller';
 import { RoleController } from './role.controller';
+import { APIController } from './api.controller';
 
 export function bindControllers(container: Container) {
   container.bind<interfaces.Controller>(TYPE.Controller).to(DashboardController).inSingletonScope().whenTargetNamed(DashboardController.TARGET_NAME);
@@ -12,4 +13,5 @@ export function bindControllers(container: Container) {
   container.bind<interfaces.Controller>(TYPE.Controller).to(QueryController).inSingletonScope().whenTargetNamed(QueryController.TARGET_NAME);
   container.bind<interfaces.Controller>(TYPE.Controller).to(AccountController).inSingletonScope().whenTargetNamed(AccountController.TARGET_NAME);
   container.bind<interfaces.Controller>(TYPE.Controller).to(RoleController).inSingletonScope().whenTargetNamed(RoleController.TARGET_NAME);
+  container.bind<interfaces.Controller>(TYPE.Controller).to(APIController).inSingletonScope().whenTargetNamed(APIController.TARGET_NAME);
 }

--- a/api/src/controller/query.controller.ts
+++ b/api/src/controller/query.controller.ts
@@ -8,6 +8,7 @@ import { QueryRequest } from '../api_models/query';
 import { RoleService } from '../services/role.service';
 import Account from '../models/account';
 import { ROLE_TYPES } from '../api_models/role';
+import ApiKey from '../models/apiKey';
 
 @ApiPath({
   path: '/query',
@@ -41,8 +42,8 @@ export class QueryController implements interfaces.Controller {
   @httpPost('/')
   public async query(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.READER);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const { type, key, query } = validate(QueryRequest, req.body);
       const result = await this.queryService.query(type, key, query);
       res.json(result);

--- a/api/src/controller/query.controller.ts
+++ b/api/src/controller/query.controller.ts
@@ -5,10 +5,8 @@ import { ApiOperationPost, ApiPath } from 'swagger-express-ts';
 import { QueryService } from '../services/query.service';
 import { validate } from '../middleware/validation';
 import { QueryRequest } from '../api_models/query';
-import { RoleService } from '../services/role.service';
-import Account from '../models/account';
 import { ROLE_TYPES } from '../api_models/role';
-import ApiKey from '../models/apiKey';
+import permission from '../middleware/permission';
 
 @ApiPath({
   path: '/query',
@@ -18,14 +16,11 @@ import ApiKey from '../models/apiKey';
 export class QueryController implements interfaces.Controller {
   public static TARGET_NAME = 'Query';
   private queryService: QueryService;
-  private roleService: RoleService;
 
   public constructor(
-    @inject('Newable<QueryService>') QueryService: inversaces.Newable<QueryService>,
-    @inject('Newable<RoleService>') RoleService: inversaces.Newable<RoleService>
+    @inject('Newable<QueryService>') QueryService: inversaces.Newable<QueryService>
   ) {
     this.queryService = new QueryService();
-    this.roleService = new RoleService();
   }
 
   @ApiOperationPost({
@@ -39,11 +34,9 @@ export class QueryController implements interfaces.Controller {
       500: { description: 'ApiError', model: 'ApiError' },
     }
   })
-  @httpPost('/')
+  @httpPost('/', permission(ROLE_TYPES.READER))
   public async query(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.READER);
       const { type, key, query } = validate(QueryRequest, req.body);
       const result = await this.queryService.query(type, key, query);
       res.json(result);

--- a/api/src/controller/role.controller.ts
+++ b/api/src/controller/role.controller.ts
@@ -4,6 +4,7 @@ import { controller, httpGet, interfaces } from 'inversify-express-utils';
 import { ApiOperationGet, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
 import { ROLE_TYPES } from '../api_models/role';
 import Account from '../models/account';
+import ApiKey from '../models/apiKey';
 import { RoleService } from '../services/role.service';
 
 @ApiPath({
@@ -32,8 +33,8 @@ export class RoleController implements interfaces.Controller {
   @httpGet('/list')
   public async list(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const account: Account = req.body.account;
-      this.roleService.checkPermission(account, ROLE_TYPES.INACTIVE);
+      const auth: Account | ApiKey | null = req.body.auth;
+      this.roleService.checkPermission(auth, ROLE_TYPES.INACTIVE);
       const result = await this.roleService.list();
       res.json(result);
     } catch (err) {

--- a/api/src/controller/role.controller.ts
+++ b/api/src/controller/role.controller.ts
@@ -3,8 +3,7 @@ import { inject, interfaces as inverfaces } from 'inversify';
 import { controller, httpGet, interfaces } from 'inversify-express-utils';
 import { ApiOperationGet, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
 import { ROLE_TYPES } from '../api_models/role';
-import Account from '../models/account';
-import ApiKey from '../models/apiKey';
+import permission from '../middleware/permission';
 import { RoleService } from '../services/role.service';
 
 @ApiPath({
@@ -30,11 +29,9 @@ export class RoleController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpGet('/list')
+  @httpGet('/list', permission(ROLE_TYPES.INACTIVE))
   public async list(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const auth: Account | ApiKey | null = req.body.auth;
-      this.roleService.checkPermission(auth, ROLE_TYPES.INACTIVE);
       const result = await this.roleService.list();
       res.json(result);
     } catch (err) {

--- a/api/src/data_sources/migrations/1660608562620-add-superadmin.ts
+++ b/api/src/data_sources/migrations/1660608562620-add-superadmin.ts
@@ -1,8 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 import bcrypt from 'bcrypt';
 import { ROLE_TYPES } from '../../api_models/role';
-import { SALT_ROUNDS } from '../../services/account.service';
 import Account from '../../models/account';
+import { SALT_ROUNDS } from '../../utils/constants';
 
 const password = process.env.SUPER_ADMIN_PASSWORD ?? 'secret';
 

--- a/api/src/data_sources/migrations/1667183651604-create-api_keys-table.ts
+++ b/api/src/data_sources/migrations/1667183651604-create-api_keys-table.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createApiKeysTable1667183651604 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `CREATE TABLE api_key
+        (
+          id uuid NOT NULL DEFAULT gen_random_uuid(),
+          name citext NOT NULL,
+          key VARCHAR NOT NULL,
+          domain VARCHAR NOT NULL,
+          role_id SMALLINT NOT NULL DEFAULT 10,
+          create_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          update_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY (id),
+          CONSTRAINT fk_role
+            FOREIGN KEY (role_id)
+              REFERENCES role (id)
+        )
+        `
+      );
+
+      await queryRunner.query(
+        `CREATE UNIQUE INDEX api_key_name_idx ON api_key (name)`
+      );
+
+      await queryRunner.query(
+        `CREATE TRIGGER on_update_api_key BEFORE UPDATE ON api_key
+        FOR EACH ROW EXECUTE PROCEDURE trigger_set_update_time()`
+      );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `DROP TRIGGER on_update_api_key ON api_key`
+      );
+
+      await queryRunner.query(
+        `DROP INDEX api_key_name_idx`
+      );
+
+      await queryRunner.query(
+        `DROP TABLE api_key`
+      );
+    }
+
+}

--- a/api/src/middleware/authorization.ts
+++ b/api/src/middleware/authorization.ts
@@ -1,9 +1,20 @@
 import * as express from 'express';
 import { AccountService } from '../services/account.service';
+import { ApiService } from '../services/api.service';
 
 export default async function authorization(req: express.Request, res: express.Response, next: express.NextFunction) {
+  // Bearer
   const auth = req.headers.authorization;
   const access_token = auth?.split(' ')[1];
-  req.body.account = await AccountService.getByToken(access_token);
+  const account = await AccountService.getByToken(access_token);
+  if (account !== null) {
+    req.body.auth = account;
+  } else {
+    //ApiKey
+    const key = req.headers['x-api-key'];
+    const domain = req.headers.origin;
+    const apiKey = await ApiService.verifyApiKey(key, domain);
+    req.body.auth = apiKey;
+  }
   next();
 } 

--- a/api/src/middleware/ensureAuthEnabled.ts
+++ b/api/src/middleware/ensureAuthEnabled.ts
@@ -1,0 +1,10 @@
+import * as express from 'express';
+import { AUTH_ENABLED } from '../utils/constants';
+import { ApiError, AUTH_NOT_ENABLED } from '../utils/errors';
+
+export default function ensureAuthEnabled(req: express.Request, res: express.Response, next: express.NextFunction) {
+  if (!AUTH_ENABLED) {
+    throw new ApiError(AUTH_NOT_ENABLED, { message: 'Authentication system is not enabled' });
+  }
+  next();
+}

--- a/api/src/middleware/ensureAuthIsAccount.ts
+++ b/api/src/middleware/ensureAuthIsAccount.ts
@@ -1,0 +1,12 @@
+import * as express from 'express';
+import Account from '../models/account';
+import ApiKey from '../models/apiKey';
+import { ApiError, FORBIDDEN } from '../utils/errors';
+
+export default function ensureAuthIsAccount(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const auth: Account | ApiKey = req.body.auth;
+  if (auth instanceof ApiKey) {
+    throw new ApiError(FORBIDDEN, { message: 'Must authenticate with bearer token' });
+  }
+  next();
+}

--- a/api/src/middleware/permission.ts
+++ b/api/src/middleware/permission.ts
@@ -1,0 +1,13 @@
+import * as express from 'express';
+import { ROLE_TYPES } from '../api_models/role';
+import Account from '../models/account';
+import ApiKey from '../models/apiKey';
+import { RoleService } from '../services/role.service';
+
+export default function permission(requiredRole: ROLE_TYPES) {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const auth: Account | ApiKey | null = req.body.auth;
+    RoleService.checkPermission(auth, requiredRole)
+    next();
+  }
+}

--- a/api/src/models/apiKey.ts
+++ b/api/src/models/apiKey.ts
@@ -1,0 +1,32 @@
+import { Column, Entity } from "typeorm";
+import { BaseModel } from "./base";
+
+@Entity()
+export default class ApiKey extends BaseModel {
+  @Column('character varying', {
+    nullable: false,
+    length: 100,
+    name: 'name',
+  })
+  name: string;
+
+  @Column('character varying', {
+    nullable: false,
+    length: 100,
+    name: 'key',
+  })
+  key: string;
+
+  @Column('character varying', {
+    nullable: false,
+    name: 'domain',
+  })
+  domain: string;
+
+  @Column('smallint', {
+    nullable: false,
+    default: 10,
+    name: 'role_id',
+  })
+  role_id: number;
+}

--- a/api/src/services/account.service.ts
+++ b/api/src/services/account.service.ts
@@ -8,10 +8,7 @@ import jwt, { JwtPayload } from 'jsonwebtoken';
 import _ from 'lodash';
 import logger from 'npmlog';
 import { ROLE_TYPES } from '../api_models/role';
-
-export const SALT_ROUNDS = 12;
-const SECRET_KEY: jwt.Secret = process.env.SECRET_KEY as jwt.Secret;
-const TOKEN_VALIDITY = 7 * 24 * 3600;
+import { SALT_ROUNDS, SECRET_KEY, TOKEN_VALIDITY } from '../utils/constants';
 
 export function redactPassword(account: Account) {
   return _.omit(account, 'password');
@@ -23,7 +20,7 @@ export class AccountService {
       return null;
     }
     try {
-      const decoded_token = jwt.verify(token, SECRET_KEY) as JwtPayload;
+      const decoded_token = jwt.verify(token, SECRET_KEY as jwt.Secret) as JwtPayload;
       const accountRepo = dashboardDataSource.getRepository(Account);
       const account = await accountRepo.findOneByOrFail({ id: decoded_token.id });
       return redactPassword(account);
@@ -45,7 +42,7 @@ export class AccountService {
     if (account.role_id <= ROLE_TYPES.INACTIVE) {
       throw new ApiError(INVALID_CREDENTIALS, { message: 'Invalid credentials' });
     }
-    const token = await jwt.sign({ id: account.id }, SECRET_KEY, { expiresIn: TOKEN_VALIDITY });
+    const token = await jwt.sign({ id: account.id }, SECRET_KEY as jwt.Secret, { expiresIn: TOKEN_VALIDITY });
     return { token, account: redactPassword(account) };
   }
 

--- a/api/src/services/api.service.ts
+++ b/api/src/services/api.service.ts
@@ -1,8 +1,8 @@
 import { dashboardDataSource } from '../data_sources/dashboard';
 import { BinaryLike, createHmac } from 'crypto';
 import bcrypt from 'bcrypt';
-import { ApiKey as ApiKeyModel,  ApiKeyFilterObject, ApiKeyPaginationResponse, ApiKeySortObject } from "../api_models/api";
-import { PaginationRequest } from "../api_models/base";
+import { ApiKey as ApiKeyModel,  ApiKeyFilterObject, ApiKeyPaginationResponse, ApiKeySortObject } from '../api_models/api';
+import { PaginationRequest } from '../api_models/base';
 import ApiKey from '../models/apiKey';
 import { SALT_ROUNDS, SECRET_KEY } from '../utils/constants';
 import logger from 'npmlog';

--- a/api/src/services/api.service.ts
+++ b/api/src/services/api.service.ts
@@ -1,0 +1,74 @@
+import { dashboardDataSource } from '../data_sources/dashboard';
+import { BinaryLike, createHmac } from 'crypto';
+import bcrypt from 'bcrypt';
+import { ApiKey as ApiKeyModel,  ApiKeyFilterObject, ApiKeyPaginationResponse, ApiKeySortObject } from "../api_models/api";
+import { PaginationRequest } from "../api_models/base";
+import ApiKey from '../models/apiKey';
+import { SALT_ROUNDS, SECRET_KEY } from '../utils/constants';
+import logger from 'npmlog';
+
+export class ApiService {
+  static async verifyApiKey(apiKey: string | string[] | undefined, domain: string | undefined): Promise<ApiKeyModel | null> {
+    if (!apiKey || !domain) {
+      return null;
+    }
+    if (apiKey instanceof Array) {
+      apiKey = apiKey[0];
+    }
+    try {
+      const apiKeyRepo = dashboardDataSource.getRepository(ApiKey);
+      const apiKeys = await apiKeyRepo.findBy({ domain });
+      for (let i = 0; i < apiKeys.length; i++) {
+        if (await bcrypt.compare(apiKey, apiKeys[i].key)) {
+          return apiKeys[i];
+        }
+      }
+      return null;
+    } catch (err) {
+      logger.warn(err);
+      return null;
+    }
+  }
+
+  async listKeys(filter: ApiKeyFilterObject | undefined, sort: ApiKeySortObject, pagination: PaginationRequest): Promise<ApiKeyPaginationResponse> {
+    const offset = pagination.pagesize * (pagination.page - 1);
+    const qb = dashboardDataSource.manager.createQueryBuilder()
+      .from(ApiKey, 'apikey')
+      .select('apikey.id', 'id')
+      .addSelect('apikey.name', 'name')
+      .addSelect('apikey.domain', 'domain')
+      .addSelect('apikey.role_id', 'role_id')
+      .orderBy(sort.field, sort.order)
+      .offset(offset).limit(pagination.pagesize);
+
+    if (filter?.search) {
+      qb.where('apikey.name ilike :nameSearch OR apikey.domain ilike :domainSearch', { nameSearch: `%${filter.search}%`, domainSearch: `%${filter.search}%` });
+    }
+
+    const datasources = await qb.getRawMany<ApiKey>();
+    const total = await qb.getCount();
+    return {
+      total,
+      offset,
+      data: datasources,
+    };
+  }
+
+  async createKey(name: string, domain: string, role_id: number): Promise<string> {
+    const apiKeyRepo = dashboardDataSource.getRepository(ApiKey);
+    const apiKey = new ApiKey();
+    apiKey.name = name;
+    apiKey.domain = domain;
+    apiKey.role_id = role_id;
+    const key = createHmac('sha256', SECRET_KEY as BinaryLike).update(name).digest('hex');
+    apiKey.key = await bcrypt.hash(key, SALT_ROUNDS);
+    await apiKeyRepo.save(apiKey);
+    return key;
+  }
+
+  async deleteKey(id: string): Promise<void> {
+    const apiKeyRepo = dashboardDataSource.getRepository(ApiKey);
+    const apiKey = await apiKeyRepo.findOneByOrFail({ id });
+    await apiKeyRepo.delete(apiKey.id);
+  }
+}

--- a/api/src/services/api.service.ts
+++ b/api/src/services/api.service.ts
@@ -1,10 +1,10 @@
 import { dashboardDataSource } from '../data_sources/dashboard';
-import { BinaryLike, createHmac } from 'crypto';
 import bcrypt from 'bcrypt';
+import { generateApiKey } from 'generate-api-key';
 import { ApiKey as ApiKeyModel,  ApiKeyFilterObject, ApiKeyPaginationResponse, ApiKeySortObject } from '../api_models/api';
 import { PaginationRequest } from '../api_models/base';
 import ApiKey from '../models/apiKey';
-import { SALT_ROUNDS, SECRET_KEY } from '../utils/constants';
+import { SALT_ROUNDS } from '../utils/constants';
 import logger from 'npmlog';
 
 export class ApiService {
@@ -60,7 +60,7 @@ export class ApiService {
     apiKey.name = name;
     apiKey.domain = domain;
     apiKey.role_id = role_id;
-    const key = createHmac('sha256', SECRET_KEY as BinaryLike).update(name).digest('hex');
+    const key = generateApiKey({ length: 32 }).toString();
     apiKey.key = await bcrypt.hash(key, SALT_ROUNDS);
     await apiKeyRepo.save(apiKey);
     return key;

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -4,6 +4,7 @@ import { QueryService } from './query.service';
 import { DataSourceService } from './datasource.service';
 import { AccountService } from './account.service';
 import { RoleService } from './role.service';
+import { ApiService } from './api.service';
 
 export function bindServices(container: Container) {
   container.bind<interfaces.Newable<DashboardService>>('Newable<DashboardService>').toConstructor<DashboardService>(DashboardService);
@@ -11,4 +12,5 @@ export function bindServices(container: Container) {
   container.bind<interfaces.Newable<QueryService>>('Newable<QueryService>').toConstructor<QueryService>(QueryService);
   container.bind<interfaces.Newable<AccountService>>('Newable<AccountService>').toConstructor<AccountService>(AccountService);
   container.bind<interfaces.Newable<RoleService>>('Newable<RoleService>').toConstructor<RoleService>(RoleService);
+  container.bind<interfaces.Newable<ApiService>>('Newable<ApiService>').toConstructor<ApiService>(ApiService);
 }

--- a/api/src/services/role.service.ts
+++ b/api/src/services/role.service.ts
@@ -12,7 +12,7 @@ export class RoleService {
     return await roleRepo.find();
   }
 
-  checkPermission(auth: Account | ApiKey | null, minimum_required_role: ROLE_TYPES): void {
+  static checkPermission(auth: Account | ApiKey | null, minimum_required_role: ROLE_TYPES): void {
     if (!AUTH_ENABLED) {
       return;
     }

--- a/api/src/services/role.service.ts
+++ b/api/src/services/role.service.ts
@@ -4,6 +4,7 @@ import { ROLE_TYPES } from '../api_models/role';
 import Account from '../models/account';
 import { ApiError, FORBIDDEN, UNAUTHORIZED } from '../utils/errors';
 import { AUTH_ENABLED } from '../utils/constants';
+import ApiKey from '../models/apiKey';
 
 export class RoleService {
   async list(): Promise<Role[]> {
@@ -11,14 +12,14 @@ export class RoleService {
     return await roleRepo.find();
   }
 
-  checkPermission(account: Account | null, minimum_required_role: ROLE_TYPES): void {
+  checkPermission(auth: Account | ApiKey | null, minimum_required_role: ROLE_TYPES): void {
     if (!AUTH_ENABLED) {
       return;
     }
-    if (!account) {
-      throw new ApiError(UNAUTHORIZED, { message: 'User not online' });
+    if (!auth) {
+      throw new ApiError(UNAUTHORIZED, { message: 'Not authenticated' });
     }
-    if (account.role_id < minimum_required_role) {
+    if (auth.role_id < minimum_required_role) {
       throw new ApiError(FORBIDDEN, { message: 'Insufficient privileges' });
     }
   }

--- a/api/src/utils/constants.ts
+++ b/api/src/utils/constants.ts
@@ -1,1 +1,4 @@
+export const SALT_ROUNDS = 12;
+export const SECRET_KEY = process.env.SECRET_KEY;
+export const TOKEN_VALIDITY = 7 * 24 * 3600;
 export const AUTH_ENABLED = parseInt(process.env.ENABLE_AUTH as string ?? 0);

--- a/api/src/utils/helpers.ts
+++ b/api/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { DataSourceOptions } from 'typeorm';
 import { DataSourceConfig } from '../api_models/datasource';
+import { AUTH_ENABLED } from './constants';
+import { ApiError, AUTH_NOT_ENABLED } from './errors';
 
 const DATABASE_CONNECTION_TIMEOUT_MS = 5000;
 
@@ -25,5 +27,11 @@ export function configureDatabaseSource(type: 'mysql' | 'postgresql', config: Da
         type: 'postgres',
         connectTimeoutMS: DATABASE_CONNECTION_TIMEOUT_MS,
       };
+  }
+}
+
+export function checkControllerActive() {
+  if (!AUTH_ENABLED) {
+    throw new ApiError(AUTH_NOT_ENABLED, { message: 'Authentication system is not enabled' });
   }
 }

--- a/api/src/utils/helpers.ts
+++ b/api/src/utils/helpers.ts
@@ -1,7 +1,5 @@
 import { DataSourceOptions } from 'typeorm';
 import { DataSourceConfig } from '../api_models/datasource';
-import { AUTH_ENABLED } from './constants';
-import { ApiError, AUTH_NOT_ENABLED } from './errors';
 
 const DATABASE_CONNECTION_TIMEOUT_MS = 5000;
 
@@ -27,11 +25,5 @@ export function configureDatabaseSource(type: 'mysql' | 'postgresql', config: Da
         type: 'postgres',
         connectTimeoutMS: DATABASE_CONNECTION_TIMEOUT_MS,
       };
-  }
-}
-
-export function checkControllerActive() {
-  if (!AUTH_ENABLED) {
-    throw new ApiError(AUTH_NOT_ENABLED, { message: 'Authentication system is not enabled' });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2578,6 +2578,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2906,6 +2911,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chance@^1.1.8:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.9.tgz#fbf409726a956415b4bde0e8db010f60b60fc01b"
+  integrity sha512-TfxnA/DcZXRTA4OekA2zL9GH8qscbbl6X0ZqU4tXhGveVY/mXWvEQLt5GwZcYXTEyEFflVtj+pG8nc8EwSm1RQ==
 
 change-case@^4.1.2:
   version "4.1.2"
@@ -4799,6 +4809,16 @@ gauge@^4.0.3:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     wide-align "^1.1.5"
+
+generate-api-key@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/generate-api-key/-/generate-api-key-1.0.2.tgz#824df381cff49031edcfe20a8ae78daf3881919b"
+  integrity sha512-4rPSpXyboIXfugOTN3/0Qaoqpzbk0sepzPS0XyxPh3UMuu+Trk+0JMyJ6mB/7FEgp7oZ1juqsRW+8wSYeKDbfA==
+  dependencies:
+    base-x "^4.0.0"
+    chance "^1.1.8"
+    rfc4648 "^1.5.2"
+    uuid "^8.3.2"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -8546,6 +8566,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmmirror.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfc4648@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.5.2.tgz#cf5dac417dd83e7f4debf52e3797a723c1373383"
+  integrity sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==
 
 rfdc@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Requires 2 headers to be set to make use of api key authentication
- X-Api-Key
- Origin

New api keys can be created using the interface: /api/key/create 
and can be deleted using: /api/key/delete.
/api/key/list returns a list of all available keys (id, name, domain, role_id). The value of the key itself is not shown. The key itself is only shown once as a response of /api/key/create

The interfaces involving accounts still only support using Bearer tokens since these are used to create/modify/delete user accounts, and have nothing to do with api keys.

The usage of api keys is limited to the domain, and the role_id used when creating a new key. This way keys don't get unlimited power over the entire api.