### PR TITLE
changed apikey to use app_id/app_secret

### DIFF
--- a/api/src/api_models/account.ts
+++ b/api/src/api_models/account.ts
@@ -1,7 +1,7 @@
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
 import { IsOptional, IsIn, ValidateNested, IsString, Length, IsUUID, IsInt, IsBoolean } from 'class-validator';
 import { Type } from 'class-transformer';
-import { FilterRequest, SortRequest, PaginationRequest, PaginationResponse } from './base';
+import { FilterRequest, SortRequest, PaginationRequest, PaginationResponse, Authentication } from './base';
 import { ROLE_TYPES } from './role';
 
 @ApiModel({
@@ -155,6 +155,16 @@ export class AccountListRequest {
     model: 'PaginationRequest',
   })
   pagination: PaginationRequest = new PaginationRequest({ page: 1, pagesize: 20 });
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({

--- a/api/src/api_models/api.ts
+++ b/api/src/api_models/api.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsIn, IsInt, IsOptional, IsString, IsUUID, Length, ValidateNested } from 'class-validator';
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
-import { FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
 import { ROLE_TYPES } from './role';
 
 @ApiModel({
@@ -28,10 +28,16 @@ export class ApiKey {
   role_id: number;
 
   @ApiModelProperty({
-    description: 'Domain of the ApiKey',
+    description: 'AppId of the ApiKey',
     required: true,
   })
-  domain: string;
+  app_id: string;
+
+  @ApiModelProperty({
+    description: 'AppSecret of the ApiKey',
+    required: true,
+  })
+  app_secret: string;
 }
 
 @ApiModel({
@@ -41,7 +47,7 @@ export class ApiKey {
 export class ApiKeyFilterObject implements FilterRequest {
   @IsOptional()
   @ApiModelProperty({
-    description: 'search term. Uses fuzzy search for name and domain',
+    description: 'search term. Uses fuzzy search for name',
     required: false,
   })
   search?: string;
@@ -52,13 +58,13 @@ export class ApiKeyFilterObject implements FilterRequest {
   name: 'ApiKeySortObject'
 })
 export class ApiKeySortObject implements SortRequest {
-  @IsIn(['name', 'domain', 'create_time'])
+  @IsIn(['name', 'create_time'])
   @ApiModelProperty({
     description: 'Field for sorting',
     required: true,
-    enum: ['name', 'domain', 'create_time'],
+    enum: ['name', 'create_time'],
   })
-  field: 'name' | 'domain' | 'create_time';
+  field: 'name' | 'create_time';
 
   @IsIn(['ASC', 'DESC'])
   @ApiModelProperty({
@@ -105,6 +111,16 @@ export class ApiKeyListRequest {
     model: 'PaginationRequest',
   })
   pagination: PaginationRequest = new PaginationRequest({ page: 1, pagesize: 20 });
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -142,13 +158,6 @@ export class ApiKeyCreateRequest {
   })
   name: string;
 
-  @IsString()
-  @ApiModelProperty({
-    description: 'Domain of the ApiKey',
-    required: true,
-  })
-  domain: string;
-
   @IsInt()
   @IsIn([ROLE_TYPES.INACTIVE, ROLE_TYPES.READER, ROLE_TYPES.AUTHOR, ROLE_TYPES.ADMIN])
   @ApiModelProperty({
@@ -157,6 +166,16 @@ export class ApiKeyCreateRequest {
     enum: [ROLE_TYPES.INACTIVE.toString(), ROLE_TYPES.READER.toString(), ROLE_TYPES.AUTHOR.toString(), ROLE_TYPES.ADMIN.toString()],
   })
   role_id: ROLE_TYPES.INACTIVE | ROLE_TYPES.READER | ROLE_TYPES.AUTHOR | ROLE_TYPES.ADMIN;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -170,4 +189,14 @@ export class ApiKeyIDRequest {
     required: true,
   })
   id: string;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }

--- a/api/src/api_models/base.ts
+++ b/api/src/api_models/base.ts
@@ -1,4 +1,4 @@
-import { IsInt, ValidationError } from 'class-validator';
+import { IsInt, IsString, ValidationError } from 'class-validator';
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
 
 export interface FilterRequest {
@@ -76,4 +76,31 @@ export class ApiError {
     model: 'ApiErrorDetail',
   })
   detail: ApiErrorDetail;
+}
+
+@ApiModel({
+  description: 'Authentication object for using app_id and app_secret',
+  name: 'Authentication',
+})
+export class Authentication {
+  @IsString()
+  @ApiModelProperty({
+    description: 'app_id',
+    required: true,
+  })
+  app_id: string;
+
+  @IsString()
+  @ApiModelProperty({
+    description: 'nonce_str',
+    required: true,
+  })
+  nonce_str: string;
+
+  @IsString()
+  @ApiModelProperty({
+    description: 'sign',
+    required: true,
+  })
+  sign: string;
 }

--- a/api/src/api_models/dashboard.ts
+++ b/api/src/api_models/dashboard.ts
@@ -1,7 +1,7 @@
 import { ApiModel, ApiModelProperty, SwaggerDefinitionConstant  } from 'swagger-express-ts';
 import { IsObject, Length, IsString, IsOptional, ValidateNested, IsUUID, IsBoolean, IsIn } from 'class-validator';
 import { Type } from 'class-transformer';
-import { FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
 
 @ApiModel({
   description: 'Dashboard entity',
@@ -126,6 +126,16 @@ export class DashboardListRequest {
     model: 'PaginationRequest',
   })
   pagination: PaginationRequest = new PaginationRequest({ page: 1, pagesize: 20 });
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -170,6 +180,16 @@ export class DashboardCreateRequest {
     type: SwaggerDefinitionConstant.JSON,
   })
   content: Record<string, any>;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -209,6 +229,16 @@ export class DashboardUpdateRequest{
     required: false,
   })
   is_removed?: boolean;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -222,4 +252,14 @@ export class DashboardIDRequest {
     required: true,
   })
   id: string;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }

--- a/api/src/api_models/datasource.ts
+++ b/api/src/api_models/datasource.ts
@@ -1,7 +1,7 @@
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
 import { Length, IsString, IsOptional, ValidateNested, IsUUID, IsIn, IsInt, IsObject } from 'class-validator';
 import { Type } from 'class-transformer';
-import { FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
 
 @ApiModel({
   description: 'Datasource config',
@@ -144,6 +144,16 @@ export class DataSourceListRequest {
     model: 'PaginationRequest',
   })
   pagination: PaginationRequest = new PaginationRequest({ page: 1, pagesize: 20 });
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -199,6 +209,16 @@ export class DataSourceCreateRequest {
     model: 'DataSourceConfig',
   })
   config: DataSourceConfig;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({
@@ -212,4 +232,14 @@ export class DataSourceIDRequest {
     required: true,
   })
   id: string;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }

--- a/api/src/api_models/index.ts
+++ b/api/src/api_models/index.ts
@@ -13,10 +13,11 @@ import {
 import { ApiKey, ApiKeyCreateRequest, ApiKeyListRequest, ApiKeyFilterObject, ApiKeyPaginationResponse, ApiKeySortObject, ApiKeyIDRequest } from './api';
 import { Role } from './role';
 import { QueryRequest, HttpParams } from './query';
-import { ApiError } from './base';
+import { ApiError, Authentication } from './base';
 
 export default {
   ApiError,
+  Authentication,
   
   Dashboard,
   DashboardFilterObject,

--- a/api/src/api_models/query.ts
+++ b/api/src/api_models/query.ts
@@ -1,5 +1,7 @@
-import { IsIn, IsObject, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsIn, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
+import { Authentication } from './base';
 
 @ApiModel({
   description: 'Query object',
@@ -27,6 +29,16 @@ export class QueryRequest {
     required: true,
   })
   query: string;
+
+  @IsOptional()
+  @Type(() => Authentication)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'authentication object for use with app_id / app_secret',
+    required: false,
+    model: 'Authentication',
+  })
+  authentication?: Authentication;
 }
 
 @ApiModel({

--- a/api/src/controller/api.controller.ts
+++ b/api/src/controller/api.controller.ts
@@ -61,8 +61,8 @@ export class APIController implements interfaces.Controller {
   @httpPost('/key/create', ensureAuthEnabled, permission(ROLE_TYPES.ADMIN))
   public async createKey(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const { name, domain, role_id } = validate(ApiKeyCreateRequest, req.body);
-      const result = await this.apiService.createKey(name, domain, role_id);
+      const { name, role_id } = validate(ApiKeyCreateRequest, req.body);
+      const result = await this.apiService.createKey(name, role_id);
       res.json(result);
     } catch (err) {
       next(err);

--- a/api/src/controller/dashboard.controller.ts
+++ b/api/src/controller/dashboard.controller.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import { inject, interfaces as inverfaces } from 'inversify';
-import { controller, httpGet, httpPost, httpPut, interfaces } from 'inversify-express-utils';
-import { ApiOperationGet, ApiOperationPost, ApiOperationPut, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
+import { controller, httpPost, httpPut, interfaces } from 'inversify-express-utils';
+import { ApiOperationPost, ApiOperationPut, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
 import { DashboardService } from '../services/dashboard.service';
 import { validate } from '../middleware/validation';
 import { DashboardListRequest, DashboardCreateRequest, DashboardUpdateRequest, DashboardIDRequest } from '../api_models/dashboard';
@@ -67,11 +67,11 @@ export class DashboardController implements interfaces.Controller {
     }
   }
 
-  @ApiOperationGet({
-    path: '/details/{id}',
+  @ApiOperationPost({
+    path: '/details',
     description: 'Show dashboard',
     parameters: {
-      path: { ['id']: { description: 'dashboard id' } }
+      body: { description: 'get dashboard request', required: true, model: 'DashboardIDRequest'}
     },
     responses: {
       200: { description: 'SUCCESS', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'Dashboard' },
@@ -79,10 +79,10 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpGet('/details/:id', permission(ROLE_TYPES.READER))
+  @httpPost('/details/:id', permission(ROLE_TYPES.READER))
   public async details(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
-      const id = req.params.id;
+      const { id } = validate(DashboardIDRequest, req.body);
       const result = await this.dashboardService.get(id);
       res.json(result);
     } catch (err) {
@@ -117,7 +117,7 @@ export class DashboardController implements interfaces.Controller {
     path: '/delete',
     description: 'Remove dashboard',
     parameters: {
-      body: { description: 'update dashboard request', required: true, model: 'DashboardIDRequest'}
+      body: { description: 'delete dashboard request', required: true, model: 'DashboardIDRequest'}
     },
     responses: {
       200: { description: 'SUCCESS', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'Dashboard' },

--- a/api/src/controller/dashboard.controller.ts
+++ b/api/src/controller/dashboard.controller.ts
@@ -79,7 +79,7 @@ export class DashboardController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError'},
     }
   })
-  @httpPost('/details/:id', permission(ROLE_TYPES.READER))
+  @httpPost('/details', permission(ROLE_TYPES.READER))
   public async details(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
       const { id } = validate(DashboardIDRequest, req.body);

--- a/api/src/controller/role.controller.ts
+++ b/api/src/controller/role.controller.ts
@@ -2,8 +2,6 @@ import * as express from 'express';
 import { inject, interfaces as inverfaces } from 'inversify';
 import { controller, httpGet, interfaces } from 'inversify-express-utils';
 import { ApiOperationGet, ApiPath, SwaggerDefinitionConstant } from 'swagger-express-ts';
-import { ROLE_TYPES } from '../api_models/role';
-import permission from '../middleware/permission';
 import { RoleService } from '../services/role.service';
 
 @ApiPath({
@@ -29,7 +27,7 @@ export class RoleController implements interfaces.Controller {
       500: { description: 'SERVER ERROR', type: SwaggerDefinitionConstant.Response.Type.OBJECT, model: 'ApiError' },
     }
   })
-  @httpGet('/list', permission(ROLE_TYPES.INACTIVE))
+  @httpGet('/list')
   public async list(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
     try {
       const result = await this.roleService.list();

--- a/api/src/dashboard_migration/index.ts
+++ b/api/src/dashboard_migration/index.ts
@@ -58,6 +58,7 @@ async function main() {
     }
   } catch (error) {
     logger.error('error migrating dashboards');
+    logger.error(error.message);
     process.exit(1);
   }
   logger.info('MIGRATION OF DASHBOARDS FINISHED');

--- a/api/src/data_sources/migrations/1667547548393-modify-api_keys-table.ts
+++ b/api/src/data_sources/migrations/1667547548393-modify-api_keys-table.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class modifyApiKeysTable1667547548393 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `TRUNCATE api_key`
+      );
+
+      await queryRunner.query(
+        `ALTER TABLE api_key
+          DROP COLUMN key,
+          DROP COLUMN domain,
+          ADD COLUMN app_id VARCHAR NOT NULL,
+          ADD COLUMN app_secret VARCHAR NOT NULL
+        `
+      );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `TRUNCATE api_key`
+      );
+
+      await queryRunner.query(
+        `ALTER TABLE api_key
+          DROP COLUMN app_id,
+          DROP COLUMN app_secret,
+          ADD COLUMN key VARCHAR NOT NULL,
+          ADD COLUMN domain VARCHAR NOT NULL
+        `
+      );
+    }
+
+}

--- a/api/src/middleware/authorization.ts
+++ b/api/src/middleware/authorization.ts
@@ -1,6 +1,8 @@
 import * as express from 'express';
+import { Authentication } from '../api_models/base';
 import { AccountService } from '../services/account.service';
 import { ApiService } from '../services/api.service';
+import { validate } from './validation';
 
 export default async function authorization(req: express.Request, res: express.Response, next: express.NextFunction) {
   // Bearer
@@ -11,10 +13,16 @@ export default async function authorization(req: express.Request, res: express.R
     req.body.auth = account;
   } else {
     //ApiKey
-    const key = req.headers['x-api-key'];
-    const domain = req.headers.origin;
-    const apiKey = await ApiService.verifyApiKey(key, domain);
-    req.body.auth = apiKey;
+    const { authentication, ...rest } = req.body;
+    try {
+      if (authentication !== undefined) {
+        const keyData = validate(Authentication, authentication);
+        const apiKey = await ApiService.verifyApiKey(keyData, rest);
+        req.body.auth = apiKey;
+      }
+    } catch (error) {
+      // Don't do anything
+    }
   }
   next();
 } 

--- a/api/src/models/apiKey.ts
+++ b/api/src/models/apiKey.ts
@@ -1,27 +1,25 @@
-import { Column, Entity } from "typeorm";
-import { BaseModel } from "./base";
+import { Column, Entity } from 'typeorm';
+import { BaseModel } from './base';
 
 @Entity()
 export default class ApiKey extends BaseModel {
   @Column('character varying', {
     nullable: false,
-    length: 100,
     name: 'name',
   })
   name: string;
 
   @Column('character varying', {
     nullable: false,
-    length: 100,
-    name: 'key',
+    name: 'app_id',
   })
-  key: string;
+  app_id: string;
 
   @Column('character varying', {
     nullable: false,
-    name: 'domain',
+    name: 'app_secret',
   })
-  domain: string;
+  app_secret: string;
 
   @Column('smallint', {
     nullable: false,

--- a/api/src/services/account.service.ts
+++ b/api/src/services/account.service.ts
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import logger from 'npmlog';
 import { ROLE_TYPES } from '../api_models/role';
 import { SALT_ROUNDS, SECRET_KEY, TOKEN_VALIDITY } from '../utils/constants';
+import { escapeLikePattern } from '../utils/helpers';
 
 export function redactPassword(account: Account) {
   return _.omit(account, 'password');
@@ -58,7 +59,7 @@ export class AccountService {
       .offset(offset).limit(pagination.pagesize);
 
     if (filter?.search) {
-      qb.where('account.name ilike :nameSearch OR account.email ilike :emailSearch', { nameSearch: `%${filter.search}%`, emailSearch: `%${filter.search}%` });
+      qb.where('account.name ilike :nameSearch OR account.email ilike :emailSearch', { nameSearch: `%${escapeLikePattern(filter.search)}%`, emailSearch: `%${escapeLikePattern(filter.search)}%` });
     }
 
     const datasources = await qb.getRawMany<Account>();

--- a/api/src/services/dashboard.service.ts
+++ b/api/src/services/dashboard.service.ts
@@ -2,6 +2,7 @@ import { PaginationRequest } from '../api_models/base';
 import { DashboardFilterObject, DashboardSortObject, DashboardPaginationResponse } from '../api_models/dashboard';
 import { dashboardDataSource } from '../data_sources/dashboard';
 import Dashboard from '../models/dashboard';
+import { escapeLikePattern } from '../utils/helpers';
 
 export class DashboardService {
   async list(filter: DashboardFilterObject | undefined, sort: DashboardSortObject, pagination: PaginationRequest): Promise<DashboardPaginationResponse> {
@@ -21,7 +22,7 @@ export class DashboardService {
       }
   
       if (filter.search) {
-        qb.andWhere('dashboard.name ilike :search', { search: `%${filter.search}%` });
+        qb.andWhere('dashboard.name ilike :search', { search: `%${escapeLikePattern(filter.search)}%` });
       }
     }
 

--- a/api/src/services/datasource.service.ts
+++ b/api/src/services/datasource.service.ts
@@ -5,7 +5,7 @@ import { dashboardDataSource } from '../data_sources/dashboard';
 import DataSource from '../models/datasource';
 import { maybeEncryptPassword, maybeDecryptPassword } from '../utils/encryption';
 import { ApiError, BAD_REQUEST } from '../utils/errors';
-import { configureDatabaseSource } from '../utils/helpers';
+import { configureDatabaseSource, escapeLikePattern } from '../utils/helpers';
 
 export class DataSourceService {
   static async getByTypeKey(type: string, key: string): Promise<DataSource> {
@@ -26,7 +26,7 @@ export class DataSourceService {
       .offset(offset).limit(pagination.pagesize);
 
     if (filter?.search) {
-      qb.where('datasource.type ilike :typeSearch OR datasource.key ilike :keySearch', { typeSearch: `%${filter.search}%`, keySearch: `%${filter.search}%` });
+      qb.where('datasource.type ilike :typeSearch OR datasource.key ilike :keySearch', { typeSearch: `%${escapeLikePattern(filter.search)}%`, keySearch: `%${escapeLikePattern(filter.search)}%` });
     }
 
     const datasources = await qb.getRawMany<DataSource>();

--- a/api/src/utils/constants.ts
+++ b/api/src/utils/constants.ts
@@ -1,4 +1,4 @@
 export const SALT_ROUNDS = 12;
 export const SECRET_KEY = process.env.SECRET_KEY;
 export const TOKEN_VALIDITY = 7 * 24 * 3600;
-export const AUTH_ENABLED = parseInt(process.env.ENABLE_AUTH as string ?? 0);
+export const AUTH_ENABLED = parseInt(process.env.ENABLE_AUTH as string ?? '0');

--- a/api/src/utils/helpers.ts
+++ b/api/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import { DataSourceOptions } from 'typeorm';
 import { DataSourceConfig } from '../api_models/datasource';
+import crypto from 'crypto';
 
 const DATABASE_CONNECTION_TIMEOUT_MS = 5000;
 
@@ -27,3 +28,32 @@ export function configureDatabaseSource(type: 'mysql' | 'postgresql', config: Da
       };
   }
 }
+
+export function escapeLikePattern(input: string): string {
+  if (!input) {
+    return input;
+  }
+  return input.replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+const marshall = (params: { [propName: string]: any }): string => {
+  params = params || {};
+  const keys = Object.keys(params).sort();
+  const kvs: string[] = [];
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i];
+    if (typeof params[k] !== 'undefined') {
+      kvs.push(`${keys[i]}=${typeof params[k] === 'object' ? JSON.stringify(params[k]) : params[k]}`);
+    }
+  }
+  return kvs.join('&');
+};
+
+export const cryptSign = (params: { [propName: string]: any }, appsecret: string): string => {
+  let temp = marshall(params);
+  temp += `&key=${appsecret}`;
+  const buffer = Buffer.from(temp);
+  const crypt = crypto.createHash('MD5');
+  crypt.update(buffer);
+  return crypt.digest('hex').toUpperCase();
+};


### PR DESCRIPTION
#331 
Changed authentication method for apikey to use app_id/app_secret

GET /dashboard/details/{id} changed to POST /dashboard/details to accommodate  posting api key authentication info. dashboard id is also sent in request body

Frontend method:
```javascript
function marshall(params) {
  params = params || {};
  let keys = Object.keys(params).sort();
  let kvs = [];
  for (let i = 0; i < keys.length; i++) {
    let k = keys[i];
    if (k != 'authentication' && params[k]) {
      kvs.push(
        keys[i] + '=' + (typeof params[k] == 'object' ? JSON.stringify(params[k]) : params[k])
      );
    } else {
        let authKeys = Object.keys(params[k]).sort();
        for (let j = 0; j < authKeys.length; j++) {
            let ak = authKeys[j];
            if (ak != 'sign' && params[k][ak]) {
                kvs.push(
                    authKeys[j] + '=' + (typeof params[k][ak] == 'object' ? JSON.stringify(params[k][ak]) : params[k][ak])
                );
            }
        }
    }
  }
  return kvs.sort().join('&');
}
function cryptSign(params, appsecret) {
  params = JSON.parse(params);
  let temp = marshall(params);
  temp += '&key=' + appsecret;
  let sign = CryptoJS.MD5(temp).toString()
  return sign.toUpperCase();
}

let body = pm.variables.replaceIn(pm.request.body.toJSON());
let sign = cryptSign(body.raw, appsecret);
```