### PR TITLE
Improved list request filters

### DIFF
--- a/api/src/api_models/account.ts
+++ b/api/src/api_models/account.ts
@@ -1,7 +1,7 @@
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
 import { IsOptional, IsIn, ValidateNested, IsString, Length, IsUUID, IsInt, IsBoolean } from 'class-validator';
 import { Type } from 'class-transformer';
-import { FilterRequest, SortRequest, PaginationRequest, PaginationResponse, Authentication } from './base';
+import { SortRequest, PaginationRequest, PaginationResponse, Authentication, FilterObject } from './base';
 import { ROLE_TYPES } from './role';
 
 @ApiModel({
@@ -88,13 +88,26 @@ export class AccountLoginResponse {
   description: 'Account filter object',
   name: 'AccountFilterObject',
 })
-export class AccountFilterObject implements FilterRequest {
+export class AccountFilterObject {
   @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'search term. Uses fuzzy search for name and email fields',
+    description: 'Filter based on name',
     required: false,
+    model: 'FilterObject',
   })
-  search?: string;
+  name?: FilterObject;
+
+  @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'Filter based on email',
+    required: false,
+    model: 'FilterObject',
+  })
+  email?: FilterObject;
 }
 
 @ApiModel({

--- a/api/src/api_models/api.ts
+++ b/api/src/api_models/api.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsIn, IsInt, IsOptional, IsString, IsUUID, Length, ValidateNested } from 'class-validator';
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
-import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterObject, PaginationRequest, PaginationResponse, SortRequest } from './base';
 import { ROLE_TYPES } from './role';
 
 @ApiModel({
@@ -50,13 +50,16 @@ export class ApiKey {
   description: 'ApiKey filter object',
   name: 'ApiKeyFilterObject',
 })
-export class ApiKeyFilterObject implements FilterRequest {
+export class ApiKeyFilterObject {
   @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'search term. Uses fuzzy search for name',
+    description: 'Filter based on name',
     required: false,
+    model: 'FilterObject',
   })
-  search?: string;
+  name?: FilterObject;
 }
 
 @ApiModel({

--- a/api/src/api_models/base.ts
+++ b/api/src/api_models/base.ts
@@ -1,9 +1,24 @@
-import { IsInt, IsString, ValidationError } from 'class-validator';
+import { IsBoolean, IsInt, IsString, ValidationError } from 'class-validator';
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
 
-export interface FilterRequest {
-  search?: string;
-  selection?: string;
+@ApiModel({
+  description: 'Filter object',
+  name: 'FilterObject',
+})
+export class FilterObject {
+  @IsString()
+  @ApiModelProperty({
+    description: 'Value to be used in the filter',
+    required: true,
+  })
+  value: string;
+
+  @IsBoolean()
+  @ApiModelProperty({
+    description: 'Wether the filter should use fuzzy matching or exact matching',
+    required: true,
+  })
+  isFuzzy: boolean;
 }
 
 export interface SortRequest {

--- a/api/src/api_models/dashboard.ts
+++ b/api/src/api_models/dashboard.ts
@@ -1,7 +1,7 @@
 import { ApiModel, ApiModelProperty, SwaggerDefinitionConstant } from 'swagger-express-ts';
 import { IsObject, Length, IsString, IsOptional, ValidateNested, IsUUID, IsBoolean, IsIn } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterObject, PaginationRequest, PaginationResponse, SortRequest } from './base';
 
 @ApiModel({
   description: 'Dashboard entity',
@@ -62,22 +62,34 @@ export class Dashboard {
   description: 'Dashboard filter object',
   name: 'DashboardFilterObject',
 })
-export class DashboardFilterObject implements FilterRequest {
+export class DashboardFilterObject {
   @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'search term. Uses fuzzy search for name and group',
+    description: 'Filter based on name',
     required: false,
+    model: 'FilterObject',
   })
-  search?: string;
+  name?: FilterObject;
 
   @IsOptional()
-  @IsIn(['ACTIVE', 'REMOVED', 'ALL'])
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'Types of dashboards to select',
+    description: 'Filter based on group',
     required: false,
-    enum: ['ACTIVE', 'REMOVED', 'ALL'],
+    model: 'FilterObject',
   })
-  selection?: 'ACTIVE' | 'REMOVED' | 'ALL';
+  group?: FilterObject;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiModelProperty({
+    description: 'filter based on is_removed',
+    required: false,
+  })
+  is_removed?: boolean;
 }
 
 @ApiModel({

--- a/api/src/api_models/dashboard_changelog.ts
+++ b/api/src/api_models/dashboard_changelog.ts
@@ -1,7 +1,7 @@
-import { Type } from "class-transformer";
-import { IsIn, IsOptional, ValidateNested } from "class-validator";
-import { ApiModel, ApiModelProperty } from "swagger-express-ts";
-import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from "./base";
+import { Type } from 'class-transformer';
+import { IsIn, IsOptional, ValidateNested } from 'class-validator';
+import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
+import { Authentication, FilterObject, PaginationRequest, PaginationResponse, SortRequest } from './base';
 
 @ApiModel({
   description: 'DashboardChangelog entity',
@@ -9,8 +9,8 @@ import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, S
 })
 export class DashboardChangelog {
   @ApiModelProperty({
-    description : 'changelog ID in uuid format' ,
-    required : false,
+    description: 'changelog ID in uuid format',
+    required: false,
   })
   id: string;
 
@@ -37,18 +37,21 @@ export class DashboardChangelog {
   description: 'DashboardChangelog filter object',
   name: 'DashboardChangelogFilterObject',
 })
-export class DashboardChangelogFilterObject implements FilterRequest {
+export class DashboardChangelogFilterObject {
   @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'search term. Uses exact match search on dashboard_id',
+    description: 'Filter based on dashboard_id. isFuzzy is ignored and always filters on exact match',
     required: false,
+    model: 'FilterObject',
   })
-  search?: string;
+  dashboard_id?: FilterObject;
 }
 
 @ApiModel({
   description: 'DashboardChangelog sort object',
-  name: 'DashboardChangelogSortObject'
+  name: 'DashboardChangelogSortObject',
 })
 export class DashboardChangelogSortObject implements SortRequest {
   @IsIn(['dashboard_id', 'create_time'])
@@ -57,7 +60,7 @@ export class DashboardChangelogSortObject implements SortRequest {
     required: true,
     enum: ['dashboard_id', 'create_time'],
   })
-  field: 'dashboard_id' | 'create_time' ;
+  field: 'dashboard_id' | 'create_time';
 
   @IsIn(['ASC', 'DESC'])
   @ApiModelProperty({

--- a/api/src/api_models/datasource.ts
+++ b/api/src/api_models/datasource.ts
@@ -1,7 +1,7 @@
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts';
 import { Length, IsString, IsOptional, ValidateNested, IsUUID, IsIn, IsInt, IsObject } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterObject, PaginationRequest, PaginationResponse, SortRequest } from './base';
 
 @ApiModel({
   description: 'Processing config of DataSource',
@@ -114,13 +114,26 @@ export class DataSource {
   description: 'DataSource filter object',
   name: 'DataSourceFilterObject',
 })
-export class DataSourceFilterObject implements FilterRequest {
+export class DataSourceFilterObject {
   @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'search term. Uses fuzzy search for type and key fields',
+    description: 'Filter based on type',
     required: false,
+    model: 'FilterObject',
   })
-  search?: string;
+  type?: FilterObject;
+
+  @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'Filter based on key',
+    required: false,
+    model: 'FilterObject',
+  })
+  key?: FilterObject;
 }
 
 @ApiModel({

--- a/api/src/api_models/index.ts
+++ b/api/src/api_models/index.ts
@@ -55,11 +55,12 @@ import {
   DashboardChangelogPaginationResponse,
   DashboardChangelogSortObject,
 } from './dashboard_changelog';
-import { ApiError, Authentication } from './base';
+import { ApiError, Authentication, FilterObject } from './base';
 
 export default {
   ApiError,
   Authentication,
+  FilterObject,
 
   Dashboard,
   DashboardFilterObject,

--- a/api/src/api_models/job.ts
+++ b/api/src/api_models/job.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsIn, IsOptional, ValidateNested } from 'class-validator';
 import { ApiModel, ApiModelProperty, SwaggerDefinitionConstant } from 'swagger-express-ts';
-import { Authentication, FilterRequest, PaginationRequest, PaginationResponse, SortRequest } from './base';
+import { Authentication, FilterObject, PaginationRequest, PaginationResponse, SortRequest } from './base';
 
 @ApiModel({
   description: 'Job entity',
@@ -57,13 +57,26 @@ export class Job {
   description: 'Job filter object',
   name: 'JobFilterObject',
 })
-export class JobFilterObject implements FilterRequest {
+export class JobFilterObject {
   @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
   @ApiModelProperty({
-    description: 'search term. Uses fuzzy search for type and status fields',
+    description: 'Filter based on type. Separate values with ;',
     required: false,
+    model: 'FilterObject',
   })
-  search?: string;
+  type?: FilterObject;
+
+  @IsOptional()
+  @Type(() => FilterObject)
+  @ValidateNested({ each: true })
+  @ApiModelProperty({
+    description: 'Filter based on status. Separate values with ;',
+    required: false,
+    model: 'FilterObject',
+  })
+  status?: FilterObject;
 }
 
 @ApiModel({

--- a/api/src/services/account.service.ts
+++ b/api/src/services/account.service.ts
@@ -68,15 +68,22 @@ export class AccountService {
       .addSelect('account.name', 'name')
       .addSelect('account.email', 'email')
       .addSelect('account.role_id', 'role_id')
+      .where('true')
       .orderBy(sort.field, sort.order)
       .offset(offset)
       .limit(pagination.pagesize);
 
-    if (filter?.search) {
-      qb.where('account.name ilike :nameSearch OR account.email ilike :emailSearch', {
-        nameSearch: `%${escapeLikePattern(filter.search)}%`,
-        emailSearch: `%${escapeLikePattern(filter.search)}%`,
-      });
+    if (filter !== undefined) {
+      if (filter.name) {
+        filter.name.isFuzzy
+          ? qb.andWhere('account.name ilike :name', { name: `%${escapeLikePattern(filter.name.value)}%` })
+          : qb.andWhere('account.name = :name', { name: filter.name.value });
+      }
+      if (filter.email) {
+        filter.email.isFuzzy
+          ? qb.andWhere('account.email ilike :email', { email: `%${escapeLikePattern(filter.email.value)}%` })
+          : qb.andWhere('account.email = :email', { email: filter.email.value });
+      }
     }
 
     const datasources = await qb.getRawMany<Account>();

--- a/api/src/services/api.service.ts
+++ b/api/src/services/api.service.ts
@@ -48,12 +48,15 @@ export class ApiService {
       .addSelect('apikey.app_secret', 'app_secret')
       .addSelect('apikey.role_id', 'role_id')
       .addSelect('apikey.is_preset', 'is_preset')
+      .where('true')
       .orderBy(sort.field, sort.order)
       .offset(offset)
       .limit(pagination.pagesize);
 
-    if (filter?.search) {
-      qb.where('apikey.name ilike :nameSearch', { nameSearch: `%${escapeLikePattern(filter.search)}%` });
+    if (filter?.name) {
+      filter.name.isFuzzy
+        ? qb.andWhere('apikey.name ilike :name', { name: `%${escapeLikePattern(filter.name.value)}%` })
+        : qb.andWhere('apikey.name = :name', { name: filter.name.value });
     }
 
     const datasources = await qb.getRawMany<ApiKey>();

--- a/api/src/services/dashboard.service.ts
+++ b/api/src/services/dashboard.service.ts
@@ -21,24 +21,24 @@ export class DashboardService {
     const qb = dashboardDataSource.manager
       .createQueryBuilder()
       .from(Dashboard, 'dashboard')
+      .where('true')
       .orderBy(`"${sort.field}"`, sort.order)
       .offset(offset)
       .limit(pagination.pagesize);
 
     if (filter !== undefined) {
-      if (filter.selection === 'ALL') {
-        qb.where('dashboard.is_removed in (true, false)');
-      } else if (filter.selection === 'REMOVED') {
-        qb.where('dashboard.is_removed = true');
-      } else {
-        qb.where('dashboard.is_removed = false');
+      if (filter.name) {
+        filter.name.isFuzzy
+          ? qb.andWhere('dashboard.name ilike :name', { name: `%${escapeLikePattern(filter.name.value)}%` })
+          : qb.andWhere('dashboard.name = :name', { name: filter.name.value });
       }
-
-      if (filter.search) {
-        qb.andWhere('dashboard.name ilike :nameSearch OR dashboard.group ilike :groupSearch', {
-          nameSearch: `%${escapeLikePattern(filter.search)}%`,
-          groupSearch: `%${escapeLikePattern(filter.search)}%`,
-        });
+      if (filter.group) {
+        filter.group.isFuzzy
+          ? qb.andWhere('dashboard.group ilike :group', { group: `%${escapeLikePattern(filter.group.value)}%` })
+          : qb.andWhere('dashboard.group = :group', { name: filter.group.value });
+      }
+      if (filter.is_removed !== undefined) {
+        qb.andWhere('dashboard.is_removed = :is_removed', { is_removed: filter.is_removed });
       }
     }
 

--- a/api/src/services/dashboard_changelog.service.ts
+++ b/api/src/services/dashboard_changelog.service.ts
@@ -48,12 +48,13 @@ export class DashboardChangelogService {
       .addSelect('dashboard_id', 'dashboard_id')
       .addSelect('diff', 'diff')
       .addSelect('create_time', 'create_time')
+      .where('true')
       .orderBy(sort.field, sort.order)
       .offset(offset)
       .limit(pagination.pagesize);
 
-    if (filter?.search) {
-      qb.andWhere('dc.dashboard_id = :search', { search: filter.search });
+    if (filter?.dashboard_id) {
+      qb.andWhere('dc.dashboard_id = :dashboard_id', { dashboard_id: filter.dashboard_id.value });
     }
 
     const dashboardChangelogs = await qb.getRawMany<DashboardChangelog>();

--- a/api/src/services/datasource.service.ts
+++ b/api/src/services/datasource.service.ts
@@ -38,15 +38,22 @@ export class DataSourceService {
       .addSelect('datasource.key', 'key')
       .addSelect('datasource.is_preset', 'is_preset')
       .addSelect('datasource.config', 'config')
+      .where('true')
       .orderBy(sort.field, sort.order)
       .offset(offset)
       .limit(pagination.pagesize);
 
-    if (filter?.search) {
-      qb.where('datasource.type ilike :typeSearch OR datasource.key ilike :keySearch', {
-        typeSearch: `%${escapeLikePattern(filter.search)}%`,
-        keySearch: `%${escapeLikePattern(filter.search)}%`,
-      });
+    if (filter !== undefined) {
+      if (filter.type) {
+        filter.type.isFuzzy
+          ? qb.andWhere('datasource.type ilike :type', { type: `%${escapeLikePattern(filter.type.value)}%` })
+          : qb.andWhere('datasource.type = :type', { type: filter.type.value });
+      }
+      if (filter.key) {
+        filter.key.isFuzzy
+          ? qb.andWhere('datasource.key ilike :key', { key: `%${escapeLikePattern(filter.key.value)}%` })
+          : qb.andWhere('datasource.key = :key', { key: filter.key.value });
+      }
     }
 
     const datasources = await qb.getRawMany<DataSource>();

--- a/api/tests/e2e/01_account.test.ts
+++ b/api/tests/e2e/01_account.test.ts
@@ -243,7 +243,7 @@ describe('AccountController', () => {
 
     it('with search filter', async () => {
       const query: AccountListRequest = {
-        filter: { search: 'account' },
+        filter: { name: { value: 'account', isFuzzy: true }, email: { value: 'account', isFuzzy: true } },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
       };

--- a/api/tests/e2e/02_apikey.test.ts
+++ b/api/tests/e2e/02_apikey.test.ts
@@ -136,16 +136,16 @@ describe('APIController', () => {
       deletedKeyId = response.body.data[1].id;
     });
 
-    it('with search filter', async () => {
+    it('with filter', async () => {
       const authentication = createAuthStruct(presetKey, {
-        filter: { search: 'preset' },
+        filter: { name: { value: 'preset', isFuzzy: true } },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
       });
       validate.mockReturnValueOnce(authentication);
 
       const query: ApiKeyListRequest = {
-        filter: { search: 'preset' },
+        filter: { name: { value: 'preset', isFuzzy: true } },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
         authentication,

--- a/api/tests/e2e/04_dashboard.test.ts
+++ b/api/tests/e2e/04_dashboard.test.ts
@@ -199,9 +199,9 @@ describe('DashboardController', () => {
       });
     });
 
-    it('with search filter', async () => {
+    it('with filters', async () => {
       const query: DashboardListRequest = {
-        filter: { search: 'dashboard' },
+        filter: { name: { value: 'dashboard', isFuzzy: true }, group: { value: '', isFuzzy: true }, is_removed: false },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
       };
@@ -240,60 +240,9 @@ describe('DashboardController', () => {
       });
     });
 
-    it('with selection ALL filter', async () => {
+    it('with is_removed false filter', async () => {
       const query: DashboardListRequest = {
-        filter: { selection: 'ALL' },
-        pagination: { page: 1, pagesize: 20 },
-        sort: { field: 'name', order: 'ASC' },
-      };
-      validate.mockReturnValueOnce(query);
-
-      const response = await server
-        .post('/dashboard/list')
-        .set('Authorization', `Bearer ${superadminLogin.token}`)
-        .send(query);
-
-      expect(response.body).toMatchObject({
-        total: 3,
-        offset: 0,
-        data: [
-          {
-            id: response.body.data[0].id,
-            name: 'dashboard1',
-            content: {},
-            create_time: response.body.data[0].create_time,
-            update_time: response.body.data[0].update_time,
-            is_removed: false,
-            is_preset: false,
-            group: '1',
-          },
-          {
-            id: response.body.data[1].id,
-            name: 'dashboard2',
-            content: {},
-            create_time: response.body.data[1].create_time,
-            update_time: response.body.data[1].update_time,
-            is_removed: false,
-            is_preset: false,
-            group: '2',
-          },
-          {
-            id: presetDashboard.id,
-            name: 'preset',
-            content: {},
-            create_time: response.body.data[2].create_time,
-            update_time: response.body.data[2].update_time,
-            is_removed: true,
-            is_preset: true,
-            group: '',
-          },
-        ],
-      });
-    });
-
-    it('with selection ACTIVE filter', async () => {
-      const query: DashboardListRequest = {
-        filter: { selection: 'ACTIVE' },
+        filter: { is_removed: false },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
       };
@@ -332,9 +281,9 @@ describe('DashboardController', () => {
       });
     });
 
-    it('with selection REMOVED filter', async () => {
+    it('with is_removed true filter', async () => {
       const query: DashboardListRequest = {
-        filter: { selection: 'REMOVED' },
+        filter: { is_removed: true },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
       };

--- a/api/tests/e2e/05_datasource.test.ts
+++ b/api/tests/e2e/05_datasource.test.ts
@@ -220,9 +220,9 @@ describe('DataSourceController', () => {
       });
     });
 
-    it('with search filter', async () => {
+    it('with filter', async () => {
       const query: DataSourceListRequest = {
-        filter: { search: 'preset' },
+        filter: { key: { value: 'preset', isFuzzy: true }, type: { value: 'sql', isFuzzy: true } },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'key', order: 'ASC' },
       };

--- a/api/tests/e2e/07_job.test.ts
+++ b/api/tests/e2e/07_job.test.ts
@@ -247,7 +247,11 @@ describe('JobController', () => {
   describe('check Dashboard', () => {
     it('dashboard content queries should be updated', async () => {
       const query: DashboardListRequest = {
-        filter: { search: 'jobDashboard' },
+        filter: {
+          name: { value: 'jobDashboard', isFuzzy: true },
+          group: { value: '', isFuzzy: true },
+          is_removed: false,
+        },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'name', order: 'ASC' },
       };
@@ -285,6 +289,7 @@ describe('JobController', () => {
             update_time: response.body.data[0].update_time,
             is_removed: false,
             is_preset: false,
+            group: 'job',
           },
         ],
       });

--- a/api/tests/e2e/08_dashboard_changelog.test.ts
+++ b/api/tests/e2e/08_dashboard_changelog.test.ts
@@ -199,9 +199,9 @@ describe('DashboardChangelogController', () => {
       changelogDashboardId = response.body.data[0].dashboard_id;
     });
 
-    it('with search filters', async () => {
+    it('with filters', async () => {
       const query: DashboardChangelogListRequest = {
-        filter: { search: changelogDashboardId },
+        filter: { dashboard_id: { value: changelogDashboardId, isFuzzy: false } },
         pagination: { page: 1, pagesize: 20 },
         sort: { field: 'create_time', order: 'ASC' },
       };

--- a/api/tests/integration/01_account.test.ts
+++ b/api/tests/integration/01_account.test.ts
@@ -390,7 +390,7 @@ describe('AccountService', () => {
 
     it('with search filter', async () => {
       const results = await accountService.list(
-        { search: 'account' },
+        { name: { value: 'account', isFuzzy: true }, email: { value: 'account', isFuzzy: true } },
         { field: 'name', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );

--- a/api/tests/integration/02_apikey.test.ts
+++ b/api/tests/integration/02_apikey.test.ts
@@ -91,7 +91,7 @@ describe('ApiService', () => {
 
     it('with search filter', async () => {
       const keys = await apiService.listKeys(
-        { search: '6' },
+        { name: { value: '6', isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );
@@ -115,7 +115,7 @@ describe('ApiService', () => {
   describe('deleteKey', () => {
     it('should delete successfully', async () => {
       let currentKeys = await apiService.listKeys(
-        { search: '6' },
+        { name: { value: '6', isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );
@@ -138,7 +138,7 @@ describe('ApiService', () => {
       deletedKeyId = currentKeys.data[0].id;
 
       currentKeys = await apiService.listKeys(
-        { search: '6' },
+        { name: { value: '6', isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );

--- a/api/tests/integration/04_dashboard.test.ts
+++ b/api/tests/integration/04_dashboard.test.ts
@@ -108,9 +108,9 @@ describe('DashboardService', () => {
       });
     });
 
-    it('with search filter', async () => {
+    it('with filter', async () => {
       const results = await dashboardService.list(
-        { search: '3' },
+        { group: { value: '2', isFuzzy: true }, name: { value: '3', isFuzzy: true }, is_removed: false },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );
@@ -127,108 +127,6 @@ describe('DashboardService', () => {
             is_removed: false,
             is_preset: false,
             group: '2',
-          },
-        ],
-      });
-    });
-
-    it('with selection ALL filter', async () => {
-      const results = await dashboardService.list(
-        { selection: 'ALL' },
-        { field: 'name', order: 'ASC' },
-        { page: 1, pagesize: 20 },
-      );
-      expect(results).toMatchObject({
-        total: 3,
-        offset: 0,
-        data: [
-          {
-            id: dashboards[0].id,
-            name: 'dashboard1',
-            content: {},
-            create_time: dashboards[0].create_time,
-            update_time: dashboards[0].update_time,
-            is_removed: true,
-            is_preset: false,
-            group: '1',
-          },
-          {
-            id: dashboards[1].id,
-            name: 'dashboard2',
-            content: {},
-            create_time: dashboards[1].create_time,
-            update_time: dashboards[1].update_time,
-            is_removed: false,
-            is_preset: true,
-            group: '1',
-          },
-          {
-            id: dashboard3.id,
-            name: 'dashboard3',
-            content: {},
-            create_time: dashboard3.create_time,
-            update_time: dashboard3.update_time,
-            is_removed: false,
-            is_preset: false,
-            group: '2',
-          },
-        ],
-      });
-    });
-
-    it('with selection ACTIVE filter', async () => {
-      const results = await dashboardService.list(
-        { selection: 'ACTIVE' },
-        { field: 'name', order: 'ASC' },
-        { page: 1, pagesize: 20 },
-      );
-      expect(results).toMatchObject({
-        total: 2,
-        offset: 0,
-        data: [
-          {
-            id: dashboards[1].id,
-            name: 'dashboard2',
-            content: {},
-            create_time: dashboards[1].create_time,
-            update_time: dashboards[1].update_time,
-            is_removed: false,
-            is_preset: true,
-            group: '1',
-          },
-          {
-            id: dashboard3.id,
-            name: 'dashboard3',
-            content: {},
-            create_time: dashboard3.create_time,
-            update_time: dashboard3.update_time,
-            is_removed: false,
-            is_preset: false,
-            group: '2',
-          },
-        ],
-      });
-    });
-
-    it('with selection REMOVED filter', async () => {
-      const results = await dashboardService.list(
-        { selection: 'REMOVED' },
-        { field: 'create_time', order: 'ASC' },
-        { page: 1, pagesize: 20 },
-      );
-      expect(results).toMatchObject({
-        total: 1,
-        offset: 0,
-        data: [
-          {
-            id: dashboards[0].id,
-            name: 'dashboard1',
-            content: {},
-            create_time: dashboards[0].create_time,
-            update_time: dashboards[0].update_time,
-            is_removed: true,
-            is_preset: false,
-            group: '1',
           },
         ],
       });

--- a/api/tests/integration/05_datasource.test.ts
+++ b/api/tests/integration/05_datasource.test.ts
@@ -113,7 +113,7 @@ describe('DataSourceService', () => {
 
     it('with search filter', async () => {
       const datasources = await datasourceService.list(
-        { search: 'pg_2' },
+        { key: { value: 'pg_2', isFuzzy: true }, type: { value: '', isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );

--- a/api/tests/integration/07_job.test.ts
+++ b/api/tests/integration/07_job.test.ts
@@ -239,7 +239,7 @@ describe('JobService', () => {
 
     it('with SUCCESS search filter', async () => {
       const results = await jobService.list(
-        { search: 'SUCCESS' },
+        { status: { value: 'SUCCESS', isFuzzy: true }, type: { value: '', isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );
@@ -351,7 +351,7 @@ describe('JobService', () => {
 
     it('with FAILED search filter', async () => {
       const results = await jobService.list(
-        { search: 'FAILED' },
+        { status: { value: 'FAILED', isFuzzy: true }, type: { value: '', isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );

--- a/api/tests/integration/08_dashboard_changelog.test.ts
+++ b/api/tests/integration/08_dashboard_changelog.test.ts
@@ -248,7 +248,7 @@ describe('DashboardChangelogService', () => {
 
     it('with search filter', async () => {
       const results = await dashboardChangelogService.list(
-        { search: changelogDashboardId },
+        { dashboard_id: { value: changelogDashboardId, isFuzzy: true } },
         { field: 'create_time', order: 'ASC' },
         { page: 1, pagesize: 20 },
       );

--- a/api/tests/unit/validation.test.ts
+++ b/api/tests/unit/validation.test.ts
@@ -78,7 +78,7 @@ describe('validation', () => {
         const data: AccountListRequest = {
           pagination: { page: 1, pagesize: 20 },
           sort: { field: 'create_time', order: 'ASC' },
-          filter: { search: '' },
+          filter: { name: { value: '', isFuzzy: true }, email: { value: '', isFuzzy: true } },
         };
 
         const result = validate(AccountListRequest, data);
@@ -368,7 +368,7 @@ describe('validation', () => {
         const data: ApiKeyListRequest = {
           pagination: { page: 1, pagesize: 20 },
           sort: { field: 'create_time', order: 'ASC' },
-          filter: { search: '' },
+          filter: { name: { value: '', isFuzzy: true } },
         };
 
         const result = validate(ApiKeyListRequest, data);
@@ -507,7 +507,7 @@ describe('validation', () => {
         const data: DashboardListRequest = {
           pagination: { page: 1, pagesize: 20 },
           sort: { field: 'create_time', order: 'ASC' },
-          filter: { search: '', selection: 'ALL' },
+          filter: { group: { value: '', isFuzzy: true }, name: { value: '', isFuzzy: true }, is_removed: false },
         };
 
         const result = validate(DashboardListRequest, data);
@@ -727,7 +727,7 @@ describe('validation', () => {
         const data: DataSourceListRequest = {
           pagination: { page: 1, pagesize: 20 },
           sort: { field: 'create_time', order: 'ASC' },
-          filter: { search: '' },
+          filter: { key: { value: '', isFuzzy: true }, type: { value: '', isFuzzy: true } },
         };
 
         const result = validate(DataSourceListRequest, data);
@@ -926,7 +926,7 @@ describe('validation', () => {
         const data: JobListRequest = {
           pagination: { page: 1, pagesize: 20 },
           sort: { field: 'create_time', order: 'ASC' },
-          filter: { search: '' },
+          filter: { status: { value: '', isFuzzy: true }, type: { value: '', isFuzzy: true } },
         };
 
         const result = validate(JobListRequest, data);
@@ -1141,7 +1141,7 @@ describe('validation', () => {
         const data: DashboardChangelogListRequest = {
           pagination: { page: 1, pagesize: 20 },
           sort: { field: 'create_time', order: 'ASC' },
-          filter: { search: '' },
+          filter: { dashboard_id: { value: '', isFuzzy: true } },
         };
 
         const result = validate(DashboardChangelogListRequest, data);

--- a/settings-form/src/api-caller/account.ts
+++ b/settings-form/src/api-caller/account.ts
@@ -13,9 +13,7 @@ export const account = {
   },
   list: async (): Promise<PaginationResponse<IAccount>> => {
     const res = await APIClient.getRequest('POST')('/account/list', {
-      filter: {
-        search: '',
-      },
+      filter: {},
       sort: {
         field: 'name',
         order: 'ASC',


### PR DESCRIPTION
Improved list request filters.
### !!!BREAKING CHANGES!!!

Example:  (Similar change for ApiKey, Datasource and Job. See changed files for exact key names)
Account Before
```javascript
{
  filter?: { 
    search?: ' '//Does fuzzy search on name and email
  }
} 
```
Account After
```javascript
{ 
  filter?: {
    name?: {
      value: '',
      isFuzzy: true | false //true: does fuzzy search. false: does exact match
    },
    email?: {
      value: '',
      isFuzzy: true | false //true: does fuzzy search. false: does exact match
  }
}
```
Dashboard before
```javascript
{
  filter?: { 
    search?: ''//Does fuzzy search on name and group,
    selection?: 'ACTIVE' | 'REMOVED' | 'ALL'
  }
} 
```
Dashboard after
```javascript
{
  filter?: {
    name?: {
      value: '',
      isFuzzy: true | false //true: does fuzzy search. false: does exact match
    },
    group?: {
      value: '',
      isFuzzy: true | false //true: does fuzzy search. false: does exact match
    },
    is_removed?: true | false //true: only deleted dashboards. false: only active dashboards, undefined: all dashboards
  }
}
```
DashboardChangelog before
```javascript
{
  filter?: { 
    search?: ' '//Does exact match on dashboard_id
  }
} 
```
DashboardChangelog after
```javascript
{
  filter?: { 
     dashboard_id?: {
      value: '',
      isFuzzy: true | false //Ignored for this case because UUID does not support fuzzy matching. Always does exact match
    },
  }
} 
```