### PR TITLE
Modified dashboard unique constraint

### DIFF
--- a/api/src/data_sources/migrations/1676446469234-modify-dashboard-unique-index-is-removed.ts
+++ b/api/src/data_sources/migrations/1676446469234-modify-dashboard-unique-index-is-removed.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class modifyDashboardUniqueIndexIsRemoved1676446469234 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX dashboard_name_preset_idx`);
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX dashboard_name_preset_idx ON dashboard (name, is_preset) WHERE is_removed = false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX dashboard_name_preset_idx`);
+
+    await queryRunner.query(`CREATE UNIQUE INDEX dashboard_name_preset_idx ON dashboard (name, is_preset)`);
+  }
+}

--- a/api/src/services/dashboard.service.ts
+++ b/api/src/services/dashboard.service.ts
@@ -69,7 +69,7 @@ export class DashboardService {
 
   async getByName(name: string, is_preset: boolean): Promise<Dashboard> {
     const dashboardRepo = dashboardDataSource.getRepository(Dashboard);
-    return await dashboardRepo.findOneByOrFail({ name, is_preset });
+    return await dashboardRepo.findOneByOrFail({ name, is_preset, is_removed: false });
   }
 
   async update(


### PR DESCRIPTION
Changed unique constraint for dashboards
is_removed = true has no uniqueness requirement.
is_removed = false uses the previous uniqueness requirement of name and is_preset. Example
dashboard 1: name = "test", is_preset = false, is_removed = false //no problem
dashboard 2: name = "test", is_preset = true,  is_removed = false //no problem
dashboard 3: name = "test", is_preset = false, is_removed = true //no problem
dashboard 4: name = "test", is_preset = false,  is_removed = true //no problem
dashboard 5: name = "test", is_preset = false, is_removed = true //no problem

trying to add new dashboard
dashboard 6: name = "test", is_preset = false, is_removed = false //will conflict with dashboard 1. Unique key violation