### PR TITLE
table 1200 api client facade

### DIFF
--- a/dashboard/src/api-caller/request.ts
+++ b/dashboard/src/api-caller/request.ts
@@ -1,4 +1,4 @@
-import axios, { Method } from 'axios';
+import axios, { AxiosRequestConfig, Method } from 'axios';
 import { DataSourceType } from '~/model';
 import { AnyObject } from '..';
 import { cryptSign } from './utils';
@@ -10,11 +10,34 @@ type TQueryPayload = {
   env?: AnyObject;
 };
 
-export const APIClient = {
-  baseURL: 'http://localhost:31200',
-  app_id: '',
-  app_secret: '',
-  getAuthentication(params: Record<string, $TSFixMe>) {
+export interface IAPIClientRequestOptions {
+  string?: boolean;
+  params?: AnyObject;
+  headers?: AnyObject;
+}
+
+export interface IAPIClient {
+  getRequest: <T = $TSFixMe>(
+    method: Method,
+    signal?: AbortSignal,
+  ) => (url: string, data: AnyObject, options?: IAPIClientRequestOptions) => Promise<T>;
+  query: <T = $TSFixMe>(signal?: AbortSignal) => (data: TQueryPayload, options?: AnyObject) => Promise<T>;
+}
+
+export class DefaultApiClient implements IAPIClient {
+  baseURL: string;
+  app_id: string;
+  app_secret: string;
+  makeQueryENV: (() => AnyObject) | null;
+
+  constructor() {
+    this.baseURL = 'http://localhost:31200';
+    this.app_id = '';
+    this.app_secret = '';
+    this.makeQueryENV = null;
+  }
+
+  getAuthentication(params: Record<string, unknown>) {
     if (!this.app_id || !this.app_secret) {
       return undefined;
     }
@@ -31,9 +54,10 @@ export const APIClient = {
         this.app_secret,
       ),
     };
-  },
+  }
+
   getRequest(method: Method, signal?: AbortSignal) {
-    return (url: string, data: $TSFixMe, options: $TSFixMe = {}) => {
+    return (url: string, data: AnyObject, options: IAPIClientRequestOptions = {}) => {
       const token = window.localStorage.getItem('token');
       const headers = {
         'X-Requested-With': 'XMLHttpRequest',
@@ -42,7 +66,7 @@ export const APIClient = {
         ...options.headers,
       };
 
-      const conf: $TSFixMe = {
+      const conf: AxiosRequestConfig = {
         baseURL: this.baseURL,
         method,
         url,
@@ -57,15 +81,15 @@ export const APIClient = {
       }
 
       return axios(conf)
-        .then((res: $TSFixMe) => {
+        .then((res) => {
           return res.data;
         })
-        .catch((err: $TSFixMe) => {
+        .catch((err: Error) => {
           return Promise.reject(err);
         });
     };
-  },
-  makeQueryENV: null as null | (() => AnyObject),
+  }
+
   query(signal?: AbortSignal) {
     return async (data: TQueryPayload, options: AnyObject = {}) => {
       if (!data.env) {
@@ -73,20 +97,41 @@ export const APIClient = {
       }
       return this.getRequest('POST', signal)('/query', data, options);
     };
-  },
-};
-
-export function configureAPIClient(config: IDashboardConfig) {
-  if (APIClient.baseURL !== config.apiBaseURL) {
-    APIClient.baseURL = config.apiBaseURL;
-  }
-  if (config.app_id) {
-    APIClient.app_id = config.app_id;
-  }
-  if (config.app_secret) {
-    APIClient.app_secret = config.app_secret;
-  }
-  if (config.makeQueryENV) {
-    APIClient.makeQueryENV = config.makeQueryENV;
   }
 }
+
+const Default = new DefaultApiClient();
+
+export function configureAPIClient(config: IDashboardConfig) {
+  if (Default.baseURL !== config.apiBaseURL) {
+    Default.baseURL = config.apiBaseURL;
+  }
+  if (config.app_id) {
+    Default.app_id = config.app_id;
+  }
+  if (config.app_secret) {
+    Default.app_secret = config.app_secret;
+  }
+  if (config.makeQueryENV) {
+    Default.makeQueryENV = config.makeQueryENV;
+  }
+}
+
+class FacadeApiClient implements IAPIClient {
+  implementation: IAPIClient = Default;
+
+  getRequest<T>(
+    method: Method,
+    signal: AbortSignal | undefined,
+  ): (url: string, data: AnyObject, options?: IAPIClientRequestOptions) => Promise<T> {
+    return this.implementation.getRequest(method, signal);
+  }
+
+  query<T>(signal: AbortSignal | undefined): (data: TQueryPayload, options?: AnyObject) => Promise<T> {
+    return this.implementation.query(signal);
+  }
+}
+
+export const facadeApiClient = new FacadeApiClient();
+
+export const APIClient: IAPIClient = facadeApiClient;

--- a/dashboard/src/api-caller/request.ts
+++ b/dashboard/src/api-caller/request.ts
@@ -3,7 +3,7 @@ import { DataSourceType } from '~/model';
 import { AnyObject } from '..';
 import { cryptSign } from './utils';
 
-type TQueryPayload = {
+export type TQueryPayload = {
   type: DataSourceType;
   key: string;
   query: string;
@@ -95,7 +95,7 @@ export class DefaultApiClient implements IAPIClient {
     return conf;
   }
 
-  buildHeader(options: IAPIClientRequestOptions) {
+  buildHeader(options: IAPIClientRequestOptions): AnyObject {
     const token = window.localStorage.getItem('token');
     return {
       'X-Requested-With': 'XMLHttpRequest',
@@ -137,12 +137,12 @@ export class FacadeApiClient implements IAPIClient {
 
   getRequest<T>(
     method: Method,
-    signal: AbortSignal | undefined,
+    signal?: AbortSignal,
   ): (url: string, data: AnyObject, options?: IAPIClientRequestOptions) => Promise<T> {
     return this.implementation.getRequest(method, signal);
   }
 
-  query<T>(signal: AbortSignal | undefined): (data: TQueryPayload, options?: AnyObject) => Promise<T> {
+  query<T>(signal?: AbortSignal): (data: TQueryPayload, options?: AnyObject) => Promise<T> {
     return this.implementation.query(signal);
   }
 }

--- a/dashboard/src/api-caller/request.ts
+++ b/dashboard/src/api-caller/request.ts
@@ -132,7 +132,7 @@ export function configureAPIClient(config: IDashboardConfig) {
   }
 }
 
-class FacadeApiClient implements IAPIClient {
+export class FacadeApiClient implements IAPIClient {
   implementation: IAPIClient = Default;
 
   getRequest<T>(
@@ -147,6 +147,9 @@ class FacadeApiClient implements IAPIClient {
   }
 }
 
+/**
+ * @example facadeApiClient.implementation = new MyAPIClient();
+ */
 export const facadeApiClient = new FacadeApiClient();
 
 export const APIClient: IAPIClient = facadeApiClient;

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -12,6 +12,7 @@ export * from './contexts';
 export * from './types';
 export * from './dashboard-editor/model';
 export * from './api-caller/request';
+export type { AnyObject } from './types/utils';
 
 import './init-dayjs';
 

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -11,6 +11,7 @@ export * from './components/panel';
 export * from './contexts';
 export * from './types';
 export * from './dashboard-editor/model';
+export * from './api-caller/request';
 
 import './init-dayjs';
 


### PR DESCRIPTION
- refactor: add IAPIClient interface
- refactor: add extension point to DefaultApiClient
- refactor: add extension point to DefaultApiClient
- chore: fix type issues

**Usage**

```ts
import type { IAPIClientRequestOptions } from '@devtable/dashboard';
import { DefaultApiClient, facadeApiClient } from '@devtable/dashboard';


class CustomApiClient extends DefaultApiClient {
  baseURL = getDevTableAPIBaseURL();

  buildHeader(options: IAPIClientRequestOptions): AnyObject {
    // customize request header here
  }

  buildAxiosConfig(
    method: Method,
    url: string,
    data: AnyObject,
    options: IAPIClientRequestOptions,
    headers: AnyObject,
    signal: AbortSignal | undefined
  ): AxiosRequestConfig {
   // customize axios config here
  }

  query(
    signal?: AbortSignal
  ) {
    return (data, options)=> {
      // manipulate query params here
      return super.query(signal)(data, options);
    }
  }
}

export function setupDevTableAPIClient() {
  if (!(facadeApiClient.implementation instanceof CustomApiClient)) {
    facadeApiClient.implementation = new CustomApiClient();
  }
}

```
