### PR TITLE
build: install with node@16

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM registry.cn-hongkong.aliyuncs.com/merico/node:lts_base_v2
+FROM docker.io/node:16 as installer
 
 ENV YARN_NPM_REGISTRY_SERVER=https://registry.npmmirror.com
 
@@ -9,7 +9,15 @@ COPY api /code/api
 WORKDIR /code/api/_build
 
 ENV YARN_VERSION 3.6.1
+ENV YARN_IGNORE_NODE 1
 
 RUN yarn set version $YARN_VERSION
 
 RUN yarn install
+
+FROM registry.cn-hongkong.aliyuncs.com/merico/node:lts_base_v2
+
+COPY --from=installer /code/api/_build /code/api/_build
+
+WORKDIR /code/api/_build
+


### PR DESCRIPTION
When building the docker image for API, the build script invokes `yarn set version xxx`, and `yarn set version` will download the latest stable version of yarn to bootstrap. However, the base build image uses node 14, which is not supported by the latest yarn.

In this PR, the build script is split into 2 stages: 1. install node_modules under node@16, 2. copy files to the base image.