### PR TITLE
feat: return JSON with both semver and commit hexsha

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -53,7 +53,10 @@ server.setConfig((application: any) => {
   });
 
   application.get('/version', (req: express.Request, res: express.Response) => {
-    res.send(process.env.npm_package_version);
+    res.json({
+      "semver": process.env.npm_package_version,
+      "version": process.env.COMMIT || "",
+    });
   });
   application.use(
     swagger.express({


### PR DESCRIPTION
return both semantic version and HEAD‘s hexsha by `/version`

<img width="1007" alt="Screenshot 2024-05-15 at 10 48 55" src="https://github.com/merico-dev/table/assets/24732569/2cad20dc-a360-4ca1-a45d-7c48c8da5a3e">
