### PR TITLE
fix(dashboard): improve module externalization logic in vite.config.ts

### DIFF
--- a/dashboard/src/components/widgets/inline-function-input/index.tsx
+++ b/dashboard/src/components/widgets/inline-function-input/index.tsx
@@ -6,7 +6,7 @@ import { FunctionEditor, MonacoEditorRestriction } from '../function-editor';
 import { useTranslation } from 'react-i18next';
 import { OnMount } from '@monaco-editor/react';
 // @ts-expect-error type of this lib
-import { constrainedEditor } from 'constrained-editor-plugin/dist/esm/constrainedEditor.js';
+import { constrainedEditor } from 'constrained-editor-plugin';
 type Props = {
   value: TFunctionString;
   onChange: (v: TFunctionString) => void;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -84,10 +84,6 @@ export default defineConfig({
       react: 'react',
       'react/jsx-runtime.js': 'react/jsx-runtime.js',
       'reactflow/dist/style.css': 'reactflow/dist/style.css',
-      'constrained-editor-plugin/dist/esm/constrainedEditor.js': resolve(
-        __dirname,
-        '../node_modules/constrained-editor-plugin/dist/esm/constrainedEditor.js',
-      ),
     },
   },
   build: {

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -45,10 +45,6 @@ export default ({ mode }) => {
         '@devtable/settings-form': workspace('settings-form', 'src'),
         'dayjs/locale': path.resolve(__dirname, '../node_modules/dayjs/locale'),
         'dayjs/plugin': path.resolve(__dirname, '../node_modules/dayjs/plugin'),
-        'constrained-editor-plugin/dist/esm/constrainedEditor.js': path.resolve(
-          __dirname,
-          '../node_modules/constrained-editor-plugin/dist/esm/constrainedEditor.js',
-        ),
       },
     },
     optimizeDeps: {


### PR DESCRIPTION
修复 `@dnd-kit/react/sortable` 被打包进 bundle 导致的运行时错误

*可视化功能可以正常工作*
![image](https://github.com/user-attachments/assets/dcad68d6-7ce1-4b50-b940-1eb5c1c2b977)

*打包结果中将造成问题的依赖正确地 externalize*
![image](https://github.com/user-attachments/assets/88abee62-67a4-451d-b8ae-a6f731bc6cfd)

