### PR TITLE
feat: add panelAddon plugin

### DIFF
--- a/dashboard/src/components/panel/panel-render/panel-render-base.tsx
+++ b/dashboard/src/components/panel/panel-render/panel-render-base.tsx
@@ -33,6 +33,7 @@ export const PanelRenderBase = observer(({ panel, panelStyle, dropdownContent }:
     >
       <Box
         className={`panel-root ${panel.title.show ? 'panel-root--show-title' : ''}`}
+        id={`panel-root-${panel.id}`}
         ref={ref}
         p={0}
         sx={{

--- a/dashboard/src/components/panel/panel-render/panel-render-base.tsx
+++ b/dashboard/src/components/panel/panel-render/panel-render-base.tsx
@@ -3,6 +3,7 @@ import { EmotionSx } from '@mantine/emotion';
 import { observer } from 'mobx-react-lite';
 import { ReactNode } from 'react';
 import { PanelContextProvider } from '~/contexts/panel-context';
+import { PanelAddonProvider } from '~/components/plugins/panel-addon';
 import { PanelRenderModelInstance } from '~/model';
 import { DescriptionPopover } from './description-popover';
 import './panel-render-base.css';
@@ -20,7 +21,6 @@ const baseStyle: EmotionSx = { border: '1px solid #e9ecef' };
 
 export const PanelRenderBase = observer(({ panel, panelStyle, dropdownContent }: IPanelBase) => {
   const { ref, downloadPanelScreenshot } = useDownloadPanelScreenshot(panel);
-  const titleHeight = panel.title.show ? '60px' : '28px';
   return (
     <PanelContextProvider
       value={{
@@ -33,7 +33,6 @@ export const PanelRenderBase = observer(({ panel, panelStyle, dropdownContent }:
     >
       <Box
         className={`panel-root ${panel.title.show ? 'panel-root--show-title' : ''}`}
-        id={`panel-root-${panel.id}`}
         ref={ref}
         p={0}
         sx={{
@@ -41,12 +40,14 @@ export const PanelRenderBase = observer(({ panel, panelStyle, dropdownContent }:
           ...panelStyle,
         }}
       >
-        <Box className="panel-description-popover-wrapper">
-          <DescriptionPopover />
-        </Box>
-        {dropdownContent}
-        <PanelTitleBar />
-        <PanelVizSection panel={panel} />
+        <PanelAddonProvider>
+          <Box className="panel-description-popover-wrapper">
+            <DescriptionPopover />
+          </Box>
+          {dropdownContent}
+          <PanelTitleBar />
+          <PanelVizSection panel={panel} />
+        </PanelAddonProvider>
       </Box>
     </PanelContextProvider>
   );

--- a/dashboard/src/components/panel/panel-render/viz/viz.tsx
+++ b/dashboard/src/components/panel/panel-render/viz/viz.tsx
@@ -12,7 +12,8 @@ import {
 } from '~/components/plugins/service/service-locator/use-service-locator';
 import { WidthAndHeight } from '~/components/plugins/viz-manager/components';
 import { ErrorBoundary } from '~/utils';
-import { useRenderPanelContext } from '../../../../contexts';
+import { usePanelAddonSlot } from '~/components/plugins/panel-addon';
+import { LayoutStateContext, useRenderPanelContext } from '../../../../contexts';
 import { IViewPanelInfo, PluginContext, tokens } from '../../../plugins';
 import { PluginVizViewComponent } from '../../plugin-adaptor';
 import './viz.css';
@@ -44,7 +45,7 @@ function usePluginViz(data: TPanelData, measure: WidthAndHeight): ReactNode | nu
           variables={variables}
           vizManager={vizManager}
         />
-        <PanelVizAddons panelId={panel.id} />
+        <PanelVizAddons />
       </ServiceLocatorProvider>
     );
   } catch (e) {
@@ -70,13 +71,23 @@ export const Viz = observer(function _Viz({ data }: IViz) {
   );
 });
 
-export const PanelVizAddons = ({ panelId }: { panelId: string }) => {
+export const PanelVizAddons = () => {
   const sl = useServiceLocator();
   const instance = sl.getRequired(tokens.instanceScope.vizInstance);
+  const { inEditMode } = useContext(LayoutStateContext);
   const addonManager = sl.getRequired(tokens.panelAddonManager);
-  const panelRoot = document.getElementById(`panel-root-${panelId}`);
+  const panelRoot = usePanelAddonSlot();
   if (!panelRoot) {
     return null;
   }
-  return createPortal(<>{addonManager.createPanelAddonNode({ viz: instance })}</>, panelRoot, 'addon');
+  return createPortal(
+    <>
+      {addonManager.createPanelAddonNode({
+        viz: instance,
+        isInEditMode: inEditMode,
+      })}
+    </>,
+    panelRoot,
+    'addon',
+  );
 };

--- a/dashboard/src/components/panel/panel-render/viz/viz.tsx
+++ b/dashboard/src/components/panel/panel-render/viz/viz.tsx
@@ -1,15 +1,19 @@
 import { useElementSize } from '@mantine/hooks';
 import { get } from 'lodash';
+import { createPortal } from 'react-dom';
 
 import { Box } from '@mantine/core';
 import { observer } from 'mobx-react-lite';
 import { ReactNode, useContext } from 'react';
 import { useConfigVizInstanceService } from '~/components/panel/use-config-viz-instance-service';
-import { ServiceLocatorProvider } from '~/components/plugins/service/service-locator/use-service-locator';
+import {
+  ServiceLocatorProvider,
+  useServiceLocator,
+} from '~/components/plugins/service/service-locator/use-service-locator';
 import { WidthAndHeight } from '~/components/plugins/viz-manager/components';
 import { ErrorBoundary } from '~/utils';
 import { useRenderPanelContext } from '../../../../contexts';
-import { IViewPanelInfo, PluginContext } from '../../../plugins';
+import { IViewPanelInfo, PluginContext, tokens } from '../../../plugins';
 import { PluginVizViewComponent } from '../../plugin-adaptor';
 import './viz.css';
 
@@ -40,6 +44,7 @@ function usePluginViz(data: TPanelData, measure: WidthAndHeight): ReactNode | nu
           variables={variables}
           vizManager={vizManager}
         />
+        <PanelVizAddons panelId={panel.id} />
       </ServiceLocatorProvider>
     );
   } catch (e) {
@@ -64,3 +69,14 @@ export const Viz = observer(function _Viz({ data }: IViz) {
     </div>
   );
 });
+
+export const PanelVizAddons = ({ panelId }: { panelId: string }) => {
+  const sl = useServiceLocator();
+  const instance = sl.getRequired(tokens.instanceScope.vizInstance);
+  const addonManager = sl.getRequired(tokens.panelAddonManager);
+  const panelRoot = document.getElementById(`panel-root-${panelId}`);
+  if (!panelRoot) {
+    return null;
+  }
+  return createPortal(<>{addonManager.createPanelAddonNode({ viz: instance })}</>, panelRoot, 'addon');
+};

--- a/dashboard/src/components/plugins/panel-addon/index.ts
+++ b/dashboard/src/components/plugins/panel-addon/index.ts
@@ -1,1 +1,2 @@
 export * from './panel-addon-manager';
+export * from './panel-addon-context';

--- a/dashboard/src/components/plugins/panel-addon/index.ts
+++ b/dashboard/src/components/plugins/panel-addon/index.ts
@@ -1,0 +1,1 @@
+export * from './panel-addon-manager';

--- a/dashboard/src/components/plugins/panel-addon/panel-addon-context.tsx
+++ b/dashboard/src/components/plugins/panel-addon/panel-addon-context.tsx
@@ -1,0 +1,21 @@
+import React, { useId } from 'react';
+
+const PanelAddonContext = React.createContext<{ addonSlotId: string | null }>({ addonSlotId: null });
+
+export function PanelAddonProvider({ children }: { children: React.ReactNode }) {
+  const id = `panel-addon-slot-${useId()}`;
+  return (
+    <PanelAddonContext.Provider value={{ addonSlotId: id }}>
+      <div style={{ position: 'static', top: 0, left: 0 }} id={id}></div>
+      {children}
+    </PanelAddonContext.Provider>
+  );
+}
+
+export function usePanelAddonSlot() {
+  const { addonSlotId } = React.useContext(PanelAddonContext);
+  if (!addonSlotId) {
+    return null;
+  }
+  return document.getElementById(addonSlotId);
+}

--- a/dashboard/src/components/plugins/panel-addon/panel-addon-manager.tsx
+++ b/dashboard/src/components/plugins/panel-addon/panel-addon-manager.tsx
@@ -1,0 +1,16 @@
+import { IPanelAddon, IPanelAddonRenderProps, IPluginManager } from '~/types/plugin';
+import React from 'react';
+
+export class PanelAddonManager {
+  constructor(private pluginManager: IPluginManager) {}
+
+  createPanelAddonNode(props: IPanelAddonRenderProps) {
+    const addons = this.pluginManager.installedPlugins
+      .flatMap((it) => it.manifest.panelAddon)
+      .filter((it) => !!it) as IPanelAddon[];
+    const nodes = addons.map((addon) => {
+      return React.createElement(addon.addonRender, { ...props, key: addon.name });
+    });
+    return <>{nodes}</>;
+  }
+}

--- a/dashboard/src/components/plugins/plugin-context.tsx
+++ b/dashboard/src/components/plugins/plugin-context.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 import { Blue, Green, Orange, Red, RedGreen, YellowBlue } from '~/components/plugins/colors';
 import { InstanceMigrator } from '~/components/plugins/instance-migrator';
 import { token } from '~/components/plugins/service/service-locator';
+import { PanelAddonManager } from '~/components/plugins/panel-addon';
 
 import { PanelModelInstance } from '~/dashboard-editor/model/panels';
 import {
@@ -39,12 +40,12 @@ import { HorizontalBarChartVizComponent } from './viz-components/horizontal-bar-
 import { MericoEstimationChartVizComponent } from './viz-components/merico-estimation-chart';
 import { MericoStatsVizComponent } from './viz-components/merico-stats';
 import { MericoHeatmapVizComponent } from './viz-components/merico-heatmap';
-import _ from 'lodash';
 
 export interface IPluginContextProps {
   pluginManager: IPluginManager;
   vizManager: VizManager;
   colorManager: IColorManager;
+  panelAddonManager: PanelAddonManager;
 }
 
 const basicColors = [
@@ -170,6 +171,7 @@ export const tokens = {
   pluginManager: token<IPluginManager>('pluginManager'),
   vizManager: token<VizManager>('vizManager'),
   colorManager: token<IColorManager>('colorManager'),
+  panelAddonManager: token<PanelAddonManager>('panelAddonManager'),
   instanceScope: {
     panelModel: token<PanelModelInstance>('panelModel'),
     vizInstance: token<VizInstance>('vizInstance'),
@@ -189,7 +191,8 @@ export const createPluginContext = (): IPluginContextProps => {
   }
   const vizManager = new VizManager(pluginManager);
   const colorManager = new ColorManager(pluginManager);
-  return { pluginManager, vizManager, colorManager };
+  const panelAddonManager = new PanelAddonManager(pluginManager);
+  return { pluginManager, vizManager, colorManager, panelAddonManager };
 };
 
 export const PluginContext = createContext<IPluginContextProps>(createPluginContext());

--- a/dashboard/src/components/plugins/service/use-top-level-services.ts
+++ b/dashboard/src/components/plugins/service/use-top-level-services.ts
@@ -7,6 +7,7 @@ export function useTopLevelServices(pluginContext: IPluginContextProps) {
     return services
       .provideValue(tokens.pluginManager, pluginContext.pluginManager)
       .provideValue(tokens.vizManager, pluginContext.vizManager)
+      .provideValue(tokens.panelAddonManager, pluginContext.panelAddonManager)
       .provideValue(tokens.colorManager, pluginContext.colorManager);
   }, []);
 }

--- a/dashboard/src/contexts/layout-state-context.ts
+++ b/dashboard/src/contexts/layout-state-context.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 
 export interface ILayoutStateContext {

--- a/dashboard/src/dashboard-editor/ui/settings/content/edit-panel/preview-panel.tsx
+++ b/dashboard/src/dashboard-editor/ui/settings/content/edit-panel/preview-panel.tsx
@@ -5,6 +5,7 @@ import '~/components/panel/panel-render/panel-render-base.css';
 import { PanelVizSection } from '~/components/panel/panel-render/viz/panel-viz-section';
 import { useRenderPanelContext } from '~/contexts';
 import { ErrorBoundary } from '~/utils';
+import { PanelAddonProvider } from '~/components/plugins/panel-addon';
 
 const PreviewTitleBar = observer(() => {
   const { panel } = useRenderPanelContext();
@@ -38,11 +39,13 @@ export const PreviewPanel = observer(() => {
           height: '450px !important',
         }}
       >
-        <Box className="panel-description-popover-wrapper">
-          <DescriptionPopover />
-        </Box>
-        <PreviewTitleBar />
-        <PanelVizSection panel={panel} />
+        <PanelAddonProvider>
+          <Box className="panel-description-popover-wrapper">
+            <DescriptionPopover />
+          </Box>
+          <PreviewTitleBar />
+          <PanelVizSection panel={panel} />
+        </PanelAddonProvider>
       </Box>
     </ErrorBoundary>
   );

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -1,6 +1,6 @@
 import { ButtonProps } from '@mantine/core';
 import './init-dayjs';
-import './i18n'; // NOTE: keep it align with global.d.ts
+import './i18n';
 
 export const getVersion = () =>
   import('../package.json').then(({ version }) => {

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -1,4 +1,6 @@
 import { ButtonProps } from '@mantine/core';
+import './init-dayjs';
+import './i18n'; // NOTE: keep it align with global.d.ts
 
 export const getVersion = () =>
   import('../package.json').then(({ version }) => {
@@ -16,9 +18,6 @@ export * from './model';
 export * from './api-caller/request';
 export type { AnyObject } from './types/utils';
 
-import './init-dayjs';
-import './i18n';
-
 // NOTE: keep it align with global.d.ts
 export interface IDashboardConfig {
   basename: string;
@@ -29,3 +28,6 @@ export interface IDashboardConfig {
   monacoPath: string;
   searchButtonProps: ButtonProps;
 }
+
+export { pluginManager } from './components/plugins';
+export { type IPanelAddon, type IPanelAddonRenderProps } from './types/plugin';

--- a/dashboard/src/types/plugin/index.ts
+++ b/dashboard/src/types/plugin/index.ts
@@ -133,6 +133,7 @@ export interface IConfigMigrator extends IPanelScopeConfigMigrator {
 
 export interface IPanelAddonRenderProps {
   viz: VizInstance;
+  isInEditMode: boolean;
 }
 
 export interface IPanelAddon {

--- a/dashboard/src/types/plugin/index.ts
+++ b/dashboard/src/types/plugin/index.ts
@@ -105,6 +105,7 @@ export type TranslationPatch = {
   lang: 'en' | 'zh';
   resources: Record<string, any>;
 }[];
+
 export interface VizComponent {
   name: string;
   displayName?: string;
@@ -130,9 +131,19 @@ export interface IConfigMigrator extends IPanelScopeConfigMigrator {
   migrate(ctx: IConfigMigrationContext): Promise<void>;
 }
 
+export interface IPanelAddonRenderProps {
+  viz: VizInstance;
+}
+
+export interface IPanelAddon {
+  name: string;
+  addonRender: React.ComponentType<IPanelAddonRenderProps>;
+}
+
 export interface IPluginManifest {
   viz: VizComponent[];
   color: IColorPaletteItem[];
+  panelAddon?: IPanelAddon[];
 }
 
 export interface IDashboardPlugin {
@@ -208,7 +219,9 @@ export interface IVizTriggerManager {
   retrieveTrigger(id: string): Promise<ITrigger | undefined>;
 
   watchTriggerSnapshotList(callback: (triggerList: ITriggerSnapshot<AnyObject>[]) => void): () => void;
+
   needMigration(): Promise<boolean>;
+
   runMigration(): Promise<void>;
 }
 
@@ -242,6 +255,7 @@ export interface IVizOperationManager {
   retrieveTrigger(operationId: string): Promise<IDashboardOperation | undefined>;
 
   runMigration(): Promise<void>;
+
   needMigration(): Promise<boolean>;
 }
 

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -21,6 +21,7 @@ import { SQLSnippetPage } from './pages/sql-snippet-page';
 import { StatusPage } from './pages/status-page';
 import { MantineProviders } from './utils/mantine-providers';
 import('./utils/configure-monaco-editor');
+import './utils/install-dashboard-website-plugin';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/website/src/utils/install-dashboard-website-plugin.tsx
+++ b/website/src/utils/install-dashboard-website-plugin.tsx
@@ -1,0 +1,50 @@
+import { IPanelAddonRenderProps, pluginManager } from '@devtable/dashboard';
+import { ActionIcon } from '@mantine/core';
+import { IconBug } from '@tabler/icons-react';
+import React from 'react';
+
+export const PrintEChartsOptionAddon = ({ viz, isInEditMode }: IPanelAddonRenderProps) => {
+  const [renderOptions, setRenderOptions] = React.useState<unknown | null>(null);
+  React.useEffect(() => {
+    const listener = (opt: unknown) => {
+      setRenderOptions(opt);
+    };
+    const channel = viz.messageChannels.getChannel('viz');
+    channel.on('rendered', listener);
+    return () => {
+      channel.off('rendered', listener);
+    };
+  }, [viz.messageChannels]);
+  if (!renderOptions || isInEditMode) {
+    return null;
+  }
+  return (
+    <div style={{ position: 'absolute', top: 2, right: 32, zIndex: 400 }}>
+      <ActionIcon
+        onClick={(ev) => {
+          ev.stopPropagation();
+          ev.preventDefault();
+          console.log('ask ai', renderOptions);
+        }}
+        size="sm"
+        variant="transparent"
+      >
+        <IconBug />
+      </ActionIcon>
+    </div>
+  );
+};
+pluginManager.install({
+  id: 'website',
+  manifest: {
+    viz: [],
+    color: [],
+    panelAddon: [
+      {
+        name: 'log-options',
+        addonRender: PrintEChartsOptionAddon,
+      },
+    ],
+  },
+  version: '0.1',
+});


### PR DESCRIPTION
改动列表：

- 添加了 PanelAddon 插件，允许用户向 Panel 中插入自定义元素
  - PanelAddon 可以通过 VizInstance 跟 panel 以及其中渲染的 Viz 交互
  - 给 panel-root 容器添加了 id，PanelAddon 生成的 DOM 会被插入到 Panel Root 下
- cartesian Viz 现在会向 VizInstance 报告 rendered 事件，PanelAddon 通过订阅该事件就可以获得 ECharts 用来渲染的配置对象
- pluginManager 现在被 exported

使用样例：
```ts
pluginManager.install({
  id: 'dev-insight',
  manifest: {
    viz: [],
    color: [],
    panelAddon: [
      {
        name: 'ask-ai',
        addonRender: AskAIAddon,
      },
    ],
  },
  version: '0.1',
});
```
![image](https://github.com/user-attachments/assets/d786e3cc-93b7-4245-8f79-8011998c60b2)


接下来的计划：

* 为更多使用 ECharts 的 Viz 添加 rendered 事件
* 允许用户在 PanelAddon 中渲染当前的 Viz