### PR TITLE
为更多的 echarts Viz 组件添加 rendered 事件支持

### DIFF
--- a/dashboard/src/components/panel/panel-render/client-panel-render.tsx
+++ b/dashboard/src/components/panel/panel-render/client-panel-render.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useDashboardContext } from '~/contexts';
 import { PanelRenderBase } from './panel-render-base';
 import { PanelVizFeatures } from './panel-viz-features';
@@ -14,7 +15,7 @@ export interface IClientPanelRenderProps {
  */
 export function ClientPanelRender(props: IClientPanelRenderProps) {
   const dashboardModel = useDashboardContext();
-  const panel = dashboardModel.content.panels.findByID(props.panelId);
+  const panel = useMemo(() => dashboardModel.content.panels.findByID(props.panelId), [props.panelId]);
   if (!panel) {
     return null;
   }

--- a/dashboard/src/components/panel/use-config-viz-instance-service.ts
+++ b/dashboard/src/components/panel/use-config-viz-instance-service.ts
@@ -8,6 +8,7 @@ import { NullInteractionManager } from '~/interactions/null-interaction-manager'
 
 export function useConfigVizInstanceService(panel: IPanelInfo, withInteraction = true) {
   const { panel: panelModel } = useRenderPanelContext();
+
   return useCallback(
     (services: IServiceLocator) => {
       const vizManager = services.getRequired(tokens.vizManager);

--- a/dashboard/src/components/plugins/index.ts
+++ b/dashboard/src/components/plugins/index.ts
@@ -3,3 +3,4 @@ export * from './plugin-context';
 export * from './plugin-data-migrator';
 export * from './hooks';
 export * from './color-manager';
+export { onVizRendered, notifyVizRendered } from './viz-components/viz-instance-api';

--- a/dashboard/src/components/plugins/viz-components/boxplot-chart/viz-boxplot-chart.tsx
+++ b/dashboard/src/components/plugins/viz-components/boxplot-chart/viz-boxplot-chart.tsx
@@ -2,7 +2,7 @@ import ReactEChartsCore from 'echarts-for-react/lib/core';
 import 'echarts-gl';
 import * as echarts from 'echarts/core';
 import _, { defaults } from 'lodash';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useStorageData } from '~/components/plugins/hooks';
 import { useRowDataMap } from '~/components/plugins/hooks/use-row-data-map';
 import { useCurrentInteractionManager, useTriggerSnapshotList } from '~/interactions';
@@ -12,6 +12,7 @@ import { getOption } from './option';
 import { ClickBoxplotSeries } from './triggers';
 import { DEFAULT_CONFIG, IBoxplotChartConf, IBoxplotDataItem } from './type';
 import { useTranslation } from 'react-i18next';
+import { notifyVizRendered } from '~/components/plugins/viz-components/viz-instance-api';
 
 interface IClickBoxplotSeries {
   type: 'click';
@@ -50,11 +51,19 @@ export function VizBoxplotChart({ context, instance }: VizViewProps) {
     [rowDataMap, triggers, interactionManager],
   );
 
+  const echartsInstanceRef = useRef<ReactEChartsCore>(null);
+  const handleFinished = useCallback(() => {
+    const chart = echartsInstanceRef.current?.getEchartsInstance();
+    if (!chart) return;
+    notifyVizRendered(instance, chart.getOption());
+  }, []);
+
   const onEvents = useMemo(() => {
     return {
       click: handleSeriesClick,
+      finished: handleFinished,
     };
-  }, [handleSeriesClick]);
+  }, [handleSeriesClick, handleFinished]);
 
   const option = useMemo(() => getOption({ config, data, variables, t }), [config, data, variables, t]);
 
@@ -66,6 +75,7 @@ export function VizBoxplotChart({ context, instance }: VizViewProps) {
       <ReactEChartsCore
         echarts={echarts}
         option={option}
+        ref={echartsInstanceRef}
         style={getBoxContentStyle(width, height)}
         onEvents={onEvents}
         notMerge

--- a/dashboard/src/components/plugins/viz-components/cartesian/viz-cartesian-chart.tsx
+++ b/dashboard/src/components/plugins/viz-components/cartesian/viz-cartesian-chart.tsx
@@ -16,6 +16,7 @@ import { getOption } from './option';
 import { updateRegressionLinesColor } from './option/events';
 import { ClickEchartSeries } from './triggers/click-echart';
 import { DEFAULT_CONFIG, ICartesianChartConf } from './type';
+import { notifyVizRendered } from '~/components/plugins/viz-components/viz-instance-api';
 
 interface IClickEchartsSeries {
   type: 'click';
@@ -118,7 +119,7 @@ export const VizCartesianChart = observer(({ context, instance }: VizViewProps) 
   const finalWidth = getBoxContentWidth(width);
 
   function handleChartRenderFinished(chartOptions: unknown) {
-    instance.messageChannels.getChannel('viz').emit('rendered', chartOptions);
+    notifyVizRendered(instance, chartOptions);
   }
 
   return (

--- a/dashboard/src/components/plugins/viz-components/funnel/viz-funnel-chart.tsx
+++ b/dashboard/src/components/plugins/viz-components/funnel/viz-funnel-chart.tsx
@@ -4,19 +4,55 @@ import { defaults } from 'lodash';
 import React, { useMemo } from 'react';
 import { useStorageData } from '~/components/plugins/hooks';
 import { DefaultVizBox, getBoxContentHeight, getBoxContentWidth } from '~/styles/viz-box';
-import { VizViewProps } from '~/types/plugin';
+import { VizInstance, VizViewProps } from '~/types/plugin';
 import { getOption } from './option';
 import { DEFAULT_CONFIG, IFunnelConf } from './type';
+import { notifyVizRendered } from '~/components/plugins/viz-components/viz-instance-api';
 
-function Chart({ conf, data, width, height }: { conf: IFunnelConf; data: TPanelData; width: number; height: number }) {
+function Chart({
+  conf,
+  data,
+  width,
+  height,
+  instance,
+}: {
+  conf: IFunnelConf;
+  data: TPanelData;
+  width: number;
+  height: number;
+  instance: VizInstance;
+}) {
   const option = React.useMemo(() => {
     return getOption(conf, data);
   }, [conf, data]);
 
-  return <ReactEChartsCore echarts={echarts} option={option} style={{ width, height }} notMerge theme="merico-light" />;
+  const echartsInstanceRef = React.useRef<ReactEChartsCore>(null);
+  const handleFinished = React.useCallback(() => {
+    const chart = echartsInstanceRef.current?.getEchartsInstance();
+    if (!chart) return;
+    notifyVizRendered(instance, chart.getOption());
+  }, [instance]);
+  const onEvents = useMemo(
+    () => ({
+      finished: handleFinished,
+    }),
+    [handleFinished],
+  );
+
+  return (
+    <ReactEChartsCore
+      ref={echartsInstanceRef}
+      onEvents={onEvents}
+      echarts={echarts}
+      option={option}
+      style={{ width, height }}
+      notMerge
+      theme="merico-light"
+    />
+  );
 }
 
-export function VizFunnelChart({ context }: VizViewProps) {
+export function VizFunnelChart({ context, instance }: VizViewProps) {
   const { value: confValue } = useStorageData<IFunnelConf>(context.instanceData, 'config');
   const conf = useMemo(() => defaults({}, confValue, DEFAULT_CONFIG), [confValue]);
   const data = context.data;
@@ -28,7 +64,13 @@ export function VizFunnelChart({ context }: VizViewProps) {
 
   return (
     <DefaultVizBox width={width} height={height}>
-      <Chart width={getBoxContentWidth(width)} height={getBoxContentHeight(height)} data={data} conf={conf} />
+      <Chart
+        instance={instance}
+        width={getBoxContentWidth(width)}
+        height={getBoxContentHeight(height)}
+        data={data}
+        conf={conf}
+      />
     </DefaultVizBox>
   );
 }

--- a/dashboard/src/components/plugins/viz-components/pareto-chart/viz-pareto-chart.tsx
+++ b/dashboard/src/components/plugins/viz-components/pareto-chart/viz-pareto-chart.tsx
@@ -71,6 +71,7 @@ export function VizParetoChart({ context, instance }: VizViewProps) {
       <ReactEChartsCore
         echarts={echarts}
         option={option}
+        ref={echartsInstanceRef}
         style={getBoxContentStyle(width, height)}
         onEvents={onEvents}
         notMerge

--- a/dashboard/src/components/plugins/viz-components/pareto-chart/viz-pareto-chart.tsx
+++ b/dashboard/src/components/plugins/viz-components/pareto-chart/viz-pareto-chart.tsx
@@ -1,12 +1,13 @@
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 import * as echarts from 'echarts/core';
 import _, { defaults } from 'lodash';
-import { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useRowDataMap } from '~/components/plugins/hooks/use-row-data-map';
 import { useCurrentInteractionManager, useTriggerSnapshotList } from '~/interactions';
 import { DefaultVizBox, getBoxContentStyle } from '~/styles/viz-box';
 import { VizViewProps } from '~/types/plugin';
 import { useStorageData } from '../../hooks';
+import { notifyVizRendered } from '../viz-instance-api';
 import { getOption } from './option';
 import { ClickParetoSeries } from './triggers';
 import { DEFAULT_CONFIG, IParetoChartConf } from './type';
@@ -49,11 +50,18 @@ export function VizParetoChart({ context, instance }: VizViewProps) {
     [rowDataMap, triggers, interactionManager],
   );
 
+  const echartsInstanceRef = React.useRef<ReactEChartsCore>(null);
+  const handleFinished = useCallback(() => {
+    const chart = echartsInstanceRef.current?.getEchartsInstance();
+    if (!chart) return;
+    notifyVizRendered(instance, chart.getOption());
+  }, [instance]);
   const onEvents = useMemo(() => {
     return {
       click: handleSeriesClick,
+      finished: handleFinished,
     };
-  }, [handleSeriesClick]);
+  }, [handleSeriesClick, handleFinished]);
 
   if (!conf || !width || !height) {
     return null;

--- a/dashboard/src/components/plugins/viz-components/sunburst/viz-sunburst.tsx
+++ b/dashboard/src/components/plugins/viz-components/sunburst/viz-sunburst.tsx
@@ -1,21 +1,35 @@
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 import * as echarts from 'echarts/core';
 import { defaults } from 'lodash';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { useStorageData } from '~/components/plugins/hooks';
 import { DefaultVizBox, getBoxContentStyle } from '~/styles/viz-box';
 import { VizViewProps } from '~/types/plugin';
+import { notifyVizRendered } from '../viz-instance-api';
 import { getOption } from './option';
 import { DEFAULT_CONFIG, ISunburstConf } from './type';
 
-export function VizSunburst({ context }: VizViewProps) {
+export function VizSunburst({ context, instance }: VizViewProps) {
   const { variables } = context;
   const { value: confValue } = useStorageData<ISunburstConf>(context.instanceData, 'config');
   const conf = useMemo(() => defaults({}, confValue, DEFAULT_CONFIG), [confValue]);
 
   const data = context.data;
   const { width, height } = context.viewport;
+
+  const echartsInstanceRef = React.useRef<ReactEChartsCore>(null);
+  const handleFinished = React.useCallback(() => {
+    const chart = echartsInstanceRef.current?.getEchartsInstance();
+    if (!chart) return;
+    notifyVizRendered(instance, chart.getOption());
+  }, [instance]);
+  const onEvents = useMemo(
+    () => ({
+      finished: handleFinished,
+    }),
+    [handleFinished],
+  );
 
   const option = useMemo(() => getOption(conf, data, variables), [conf, data, variables]);
 
@@ -27,6 +41,8 @@ export function VizSunburst({ context }: VizViewProps) {
       <ReactEChartsCore
         echarts={echarts}
         option={option}
+        ref={echartsInstanceRef}
+        onEvents={onEvents}
         style={getBoxContentStyle(width, height)}
         notMerge
         theme="merico-light"

--- a/dashboard/src/components/plugins/viz-components/viz-instance-api.ts
+++ b/dashboard/src/components/plugins/viz-components/viz-instance-api.ts
@@ -1,0 +1,27 @@
+import { VizInstance } from '~/types/plugin';
+import { IPanelInfo } from '~/components/plugins';
+
+/**
+ * Emit viz rendered event
+ * @param instance
+ * @param data
+ */
+export function notifyVizRendered(instance: VizInstance, data: unknown) {
+  instance.messageChannels.getChannel('viz').emit('rendered', data);
+}
+
+export interface IVizRenderedPayload {
+  panel: IPanelInfo;
+}
+
+/**
+ * Subscribe to viz rendered event of a viz instance
+ * @param instance
+ * @param callback
+ */
+export function onVizRendered(instance: VizInstance, callback: (data: unknown) => void) {
+  instance.messageChannels.getChannel('viz').on('rendered', callback);
+  return () => {
+    instance.messageChannels.getChannel('viz').off('rendered', callback);
+  };
+}

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -29,5 +29,5 @@ export interface IDashboardConfig {
   searchButtonProps: ButtonProps;
 }
 
-export { pluginManager } from './components/plugins';
+export { pluginManager, onVizRendered, notifyVizRendered } from './components/plugins';
 export { type IPanelAddon, type IPanelAddonRenderProps } from './types/plugin';

--- a/dashboard/src/model/meta-model/dashboard/content/panel/viz.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/viz.ts
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import { types } from 'mobx-state-tree';
 import { AnyObject } from '~/types';
 
@@ -19,6 +20,7 @@ export const PanelVizMeta = types
       self.type = type;
     },
     setConf(conf: AnyObject) {
+      if (isEqual(self.conf, conf)) return;
       self.conf = conf;
     },
   }));


### PR DESCRIPTION
* 为更多的 echarts Viz 组件添加 rendered 事件支持
  * 现在的 Viz 组件可以通过调用 `notifyVizRendered` 产生 `rendered` 事件
  * 用户侧可以通过 `onVizRendered` 订阅 VizInstance 的 `rendered` 事件
  * 注意：目前的 VizInstance 与 PanelId 存在 1 对 1 的关系，所以同一个 panel 上的 viz instance 的 Rendered 事件可能会被触发多次（例如，使用 ClientPanelRender 将同一个 Panel 在不同地方渲染了很多次），目前还没什么很好的处理办法，只能在订阅 `onVizRendered` 时注意一下。
* 修复了 ClientPanelRender 导致已有 Panel 重新渲染的问题