### PR TITLE
fix(dashboard): remove redundant locale prop in Calendar

### DIFF
--- a/dashboard/src/components/filter/filter-date-range/widget/calendar.tsx
+++ b/dashboard/src/components/filter/filter-date-range/widget/calendar.tsx
@@ -1,7 +1,6 @@
 import { DatePicker } from '@mantine/dates';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { DateRangeValue, DateRangeValue_Value } from '~/model';
 
 type Props = {
@@ -12,7 +11,6 @@ type Props = {
   allowSingleDateInRange: boolean;
 };
 export const Calendar = ({ value, onChange, close, max_days, allowSingleDateInRange }: Props) => {
-  const { i18n } = useTranslation();
   const v = value.value;
   const [begin, end] = v;
   const dateLeft = useMemo(() => {
@@ -59,7 +57,6 @@ export const Calendar = ({ value, onChange, close, max_days, allowSingleDateInRa
       minDate={minDate}
       maxDate={maxDate}
       allowSingleDateInRange={allowSingleDateInRange}
-      locale={i18n.language}
     />
   );
 };


### PR DESCRIPTION
Calendar 添加的 locale Prop 是多余的，因为 DatesProvider 已经在 dashboard-render/editor 上添加了。另外，这里的 locale 也没有被 lang2dayjsLocale 处理，跟 [DatesProvider](https://github.com/merico-dev/table/blob/5b8b70912ea0adc6085e05f1c7ecafd22658b349/dashboard/src/contexts/dates-provider.tsx#L11-L11) 的行为不一致。


修复后，Calendar 将采用 dashboard-render/editor 配置的 DatesProvider locale：
![image](https://github.com/user-attachments/assets/9f378f63-b2fb-471e-b3e9-b7b989238344)
![image](https://github.com/user-attachments/assets/59e1b9b7-c696-4818-b586-d8cb9eae5ef6)
