### PR TITLE
fix(dashboard): avoid render PanelVizAddons in ClientPanelRender

### DIFF
--- a/dashboard/src/components/panel/panel-render/viz/viz.tsx
+++ b/dashboard/src/components/panel/panel-render/viz/viz.tsx
@@ -78,8 +78,9 @@ export const PanelVizAddons = () => {
   const instance = sl.getRequired(tokens.instanceScope.vizInstance);
   const { inEditMode } = useContext(LayoutStateContext);
   const addonManager = sl.getRequired(tokens.panelAddonManager);
+  const { withAddon } = usePanelVizFeatures();
   const panelRoot = usePanelAddonSlot();
-  if (!panelRoot) {
+  if (!panelRoot || !withAddon) {
     return null;
   }
   return createPortal(


### PR DESCRIPTION
开发者在使用 PanelAddon 时，可能会用 ClientPanelRender 在 Panel 的逻辑树内部渲染当前 Panel，这就有可能造成递归的渲染。之前采取了一些措施来避免这种情况： https://github.com/merico-dev/table/blob/2cb3da9a7d6fc4a21957e3dafa16e6a07a14ac91/dashboard/src/components/panel/panel-render/panel-render-base.tsx#L26-L26

但是这里的处理不够彻底，因为在逻辑树上递归渲染的缘故，里层的 PanelVizAddons 组件可能会将 Addon 挂载到顶层的普通 Panel 上。

现在 PanelVizAddons 组件会检查当前的 `withAddon` 状态（ClientPanelRender 会将其设置为 false），从而避免递归渲染 Addon。