### PR TITLE
fix(dashboard): destroy created viz components after model recreation

### DIFF
--- a/dashboard/src/components/plugins/service/use-top-level-services.ts
+++ b/dashboard/src/components/plugins/service/use-top-level-services.ts
@@ -3,11 +3,14 @@ import { IPluginContextProps, tokens } from '~/components/plugins';
 import { IServiceLocator } from '~/components/plugins/service/service-locator';
 
 export function useTopLevelServices(pluginContext: IPluginContextProps) {
-  return React.useCallback((services: IServiceLocator) => {
-    return services
-      .provideValue(tokens.pluginManager, pluginContext.pluginManager)
-      .provideValue(tokens.vizManager, pluginContext.vizManager)
-      .provideValue(tokens.panelAddonManager, pluginContext.panelAddonManager)
-      .provideValue(tokens.colorManager, pluginContext.colorManager);
-  }, []);
+  return React.useCallback(
+    (services: IServiceLocator) => {
+      return services
+        .provideValue(tokens.pluginManager, pluginContext.pluginManager)
+        .provideValue(tokens.vizManager, pluginContext.vizManager)
+        .provideValue(tokens.panelAddonManager, pluginContext.panelAddonManager)
+        .provideValue(tokens.colorManager, pluginContext.colorManager);
+    },
+    [pluginContext],
+  );
 }

--- a/dashboard/src/dashboard-render/dashboard-render.tsx
+++ b/dashboard/src/dashboard-render/dashboard-render.tsx
@@ -76,7 +76,7 @@ const _ReadOnlyDashboard = ({
         filterValues ?? {},
         activeTab ?? null,
       ),
-    [dashboard, content, activeTab],
+    [dashboard, content],
   );
   useInteractionOperationHacks(model.content, false);
 

--- a/dashboard/src/dashboard-render/dashboard-render.tsx
+++ b/dashboard/src/dashboard-render/dashboard-render.tsx
@@ -113,7 +113,7 @@ const _ReadOnlyDashboard = ({
     }
   }, [activeTab, model.content.views.setFirstVisibleTabsViewActiveTab]);
 
-  const pluginContext = useCreation(createPluginContext, []);
+  const pluginContext = useCreation(createPluginContext, [model]);
   const configureServices = useTopLevelServices(pluginContext);
 
   useWhyDidYouUpdate('@devtable/dashboard render', {


### PR DESCRIPTION
1.  `activeTab` 已经有另外的 `useEffect` 来更新了，所以不需要重新创建 model
2. 在重新创建 model 的时候，也销毁掉 VizManager 中保存的状态，确保 panel.viz.conf 跟 VizInstance.instanceData 能保持同步