### PR TITLE
enhance dashboard context types

### DIFF
--- a/dashboard/src/components/plugins/index.ts
+++ b/dashboard/src/components/plugins/index.ts
@@ -4,3 +4,6 @@ export * from './plugin-data-migrator';
 export * from './hooks';
 export * from './color-manager';
 export { onVizRendered, notifyVizRendered } from './viz-components/viz-instance-api';
+export { ServiceLocator, Token } from './service/service-locator';
+export { useServiceLocator } from './service/service-locator/use-service-locator';
+export type { IServiceLocator, IDisposable } from './service/service-locator';

--- a/dashboard/src/contexts/content-model-context.ts
+++ b/dashboard/src/contexts/content-model-context.ts
@@ -7,7 +7,7 @@ export const ContentModelContext = React.createContext<ContentModelInstance | Co
 
 export const ContentModelContextProvider = ContentModelContext.Provider;
 
-function useContentModelContext<T = ContentModelInstance>() {
+export function useContentModelContext<T = ContentModelInstance>() {
   const model = React.useContext(ContentModelContext);
   if (!model) {
     throw new Error('Please use ContentModelContextProvider');
@@ -15,4 +15,3 @@ function useContentModelContext<T = ContentModelInstance>() {
   return model as T;
 }
 export const useEditContentModelContext = () => useContentModelContext<ContentModelInstance>();
-export const useRenderContentModelContext = () => useContentModelContext<IContentRenderModel>();

--- a/dashboard/src/contexts/content-model-context.ts
+++ b/dashboard/src/contexts/content-model-context.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 import { ContentModelInstance } from '~/dashboard-editor/model/content';
-import { ContentRenderModelInstance, type IContentRenderModel } from '~/dashboard-render/model/content';
+import { ContentRenderModelInstance } from '~/dashboard-render/model/content';
+import { IContentRenderModel } from '../dashboard-render/model/types';
 
-const ContentModelContext = React.createContext<ContentModelInstance | ContentRenderModelInstance | null>(null);
+export const ContentModelContext = React.createContext<ContentModelInstance | ContentRenderModelInstance | null>(null);
 
 export const ContentModelContextProvider = ContentModelContext.Provider;
 

--- a/dashboard/src/contexts/content-model-context.ts
+++ b/dashboard/src/contexts/content-model-context.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ContentModelInstance } from '~/dashboard-editor/model/content';
-import { ContentRenderModelInstance } from '~/dashboard-render/model/content';
+import { ContentRenderModelInstance, type IContentRenderModel } from '~/dashboard-render/model/content';
 
 const ContentModelContext = React.createContext<ContentModelInstance | ContentRenderModelInstance | null>(null);
 
@@ -14,4 +14,4 @@ function useContentModelContext<T = ContentModelInstance>() {
   return model as T;
 }
 export const useEditContentModelContext = () => useContentModelContext<ContentModelInstance>();
-export const useRenderContentModelContext = () => useContentModelContext<ContentRenderModelInstance>();
+export const useRenderContentModelContext = () => useContentModelContext<IContentRenderModel>();

--- a/dashboard/src/contexts/dashboard-context.ts
+++ b/dashboard/src/contexts/dashboard-context.ts
@@ -15,3 +15,4 @@ export function useDashboardContext<T = DashboardModelInstance>() {
 }
 
 export const useEditDashboardContext = () => useDashboardContext<DashboardModelInstance>();
+export const useRenderDashboardContext = () => useDashboardContext<DashboardRenderModelInstance>();

--- a/dashboard/src/contexts/dashboard-context.ts
+++ b/dashboard/src/contexts/dashboard-context.ts
@@ -15,4 +15,3 @@ export function useDashboardContext<T = DashboardModelInstance>() {
 }
 
 export const useEditDashboardContext = () => useDashboardContext<DashboardModelInstance>();
-export const useRenderDashboardContext = () => useDashboardContext<DashboardRenderModelInstance>();

--- a/dashboard/src/contexts/index.ts
+++ b/dashboard/src/contexts/index.ts
@@ -5,3 +5,4 @@ export * from './layout-state-context';
 export * from './panel-context';
 export * from './full-screen-panel-context';
 export * from './dates-provider';
+export * from './render-content-model-context';

--- a/dashboard/src/contexts/render-content-model-context.ts
+++ b/dashboard/src/contexts/render-content-model-context.ts
@@ -1,0 +1,6 @@
+import { IContentRenderModel } from '../dashboard-render';
+import { useDashboardContext } from './dashboard-context';
+
+export const useRenderDashboardContext = () => useDashboardContext<IContentRenderModel>();
+
+// use a separate file to allow tsc generate proper types

--- a/dashboard/src/contexts/render-content-model-context.ts
+++ b/dashboard/src/contexts/render-content-model-context.ts
@@ -1,6 +1,6 @@
 import { IContentRenderModel } from '../dashboard-render';
-import { useDashboardContext } from './dashboard-context';
+import { useContentModelContext } from './content-model-context';
 
-export const useRenderDashboardContext = () => useDashboardContext<IContentRenderModel>();
+export const useRenderContentModelContext = () => useContentModelContext<IContentRenderModel>();
 
 // use a separate file to allow tsc generate proper types

--- a/dashboard/src/dashboard-editor/ui/settings/content/data-preview/query-state-message.tsx
+++ b/dashboard/src/dashboard-editor/ui/settings/content/data-preview/query-state-message.tsx
@@ -22,7 +22,7 @@ export const QueryStateMessage = observer(({ queryID }: IQueryStateMessage) => {
   if (!!error || !!metricQueryPayloadErrorString) {
     return (
       <Text mt={10} c="red" size="md" ta="center" ff="monospace">
-        {error ?? metricQueryPayloadErrorString}
+        {(error as unknown as string) ?? metricQueryPayloadErrorString}
       </Text>
     );
   }

--- a/dashboard/src/dashboard-editor/ui/settings/content/data-preview/query-state-message.tsx
+++ b/dashboard/src/dashboard-editor/ui/settings/content/data-preview/query-state-message.tsx
@@ -22,7 +22,7 @@ export const QueryStateMessage = observer(({ queryID }: IQueryStateMessage) => {
   if (!!error || !!metricQueryPayloadErrorString) {
     return (
       <Text mt={10} c="red" size="md" ta="center" ff="monospace">
-        {(error as unknown as string) ?? metricQueryPayloadErrorString}
+        {error ?? metricQueryPayloadErrorString}
       </Text>
     );
   }

--- a/dashboard/src/dashboard-render/model/content.ts
+++ b/dashboard/src/dashboard-render/model/content.ts
@@ -1,44 +1,38 @@
 import {
-  Instance,
-  SnapshotIn,
-  SnapshotOut,
   addDisposer,
   applyPatch,
   getParent,
+  Instance,
   onSnapshot,
+  SnapshotIn,
+  SnapshotOut,
   types,
 } from 'mobx-state-tree';
 import { TAdditionalQueryInfo } from '~/api-caller/request';
 import {
   ContextRecordType,
   FiltersRenderModel,
-  ILayoutsRenderModel,
-  IMockContextMeta,
-  IPanelsRenderModel,
-  IQueriesRenderModel,
-  ISQLSnippetsRenderModel,
-  IViewsRenderModel,
-  LayoutsRenderModel,
-  MockContextMeta,
-  PanelsRenderModel,
-  QueriesRenderModel,
-  SQLSnippetsRenderModel,
-  TPayloadForSQL,
-  TPayloadForViz,
-  TabInfo,
-  ViewsRenderModel,
   formatSQLSnippet,
   getInitialFiltersConfig,
   getInitialMockContextMeta,
   getInitialQueriesRenderModel,
   getInitialSQLSnippetsRenderModel,
   getInitialViewsRenderModel,
-  type IFiltersRenderModel,
   type IQueryRenderModelData,
+  LayoutsRenderModel,
+  MockContextMeta,
+  PanelsRenderModel,
+  QueriesRenderModel,
+  SQLSnippetsRenderModel,
+  TabInfo,
+  TPayloadForSQL,
+  TPayloadForViz,
+  ViewsRenderModel,
 } from '~/model';
 import { DashboardContentDBType } from '~/types';
 import { typeAssert } from '~/types/utils';
 import { payloadToDashboardState } from '~/utils';
+import { IContentRenderModel } from './types';
 
 export const ContentRenderModel = types
   .model({
@@ -182,36 +176,6 @@ export const ContentRenderModel = types
 export type ContentRenderModelInstance = Instance<typeof ContentRenderModel>;
 export type ContentRenderModelCreationType = SnapshotIn<ContentRenderModelInstance>;
 export type ContentRenderModelSnapshotType = SnapshotOut<ContentRenderModelInstance>;
-
-export interface IContentRenderModel {
-  id: string;
-  name: string;
-  dashboard_id: string;
-  create_time: string;
-  update_time: string;
-  version: string;
-  filters: IFiltersRenderModel;
-  queries: IQueriesRenderModel;
-  sqlSnippets: ISQLSnippetsRenderModel;
-  views: IViewsRenderModel;
-  panels: IPanelsRenderModel;
-  layouts: ILayoutsRenderModel;
-  mock_context: IMockContextMeta;
-
-  readonly json: DashboardContentDBType;
-  readonly contentJSON: DashboardContentDBType['content'];
-  readonly payloadForSQL: TPayloadForSQL;
-  readonly payloadForViz: TPayloadForViz;
-  readonly dashboardState: ReturnType<typeof payloadToDashboardState>;
-  getAdditionalQueryInfo(query_id: string): TAdditionalQueryInfo;
-  readonly data: Record<string, IQueryRenderModelData>;
-  getDataStuffByID(queryID: string): {
-    data: IQueryRenderModelData;
-    len: number;
-    state: string;
-    error?: string;
-  };
-}
 
 typeAssert.shouldExtends<ContentRenderModelInstance, IContentRenderModel>();
 typeAssert.shouldExtends<IContentRenderModel, ContentRenderModelInstance>();

--- a/dashboard/src/dashboard-render/model/content.ts
+++ b/dashboard/src/dashboard-render/model/content.ts
@@ -129,7 +129,7 @@ export const ContentRenderModel = types
       data: IQueryRenderModelData;
       len: number;
       state: string;
-      error?: Error;
+      error?: string;
     } {
       const q = self.queries.findByID(queryID);
       if (!q) {
@@ -209,7 +209,7 @@ export interface IContentRenderModel {
     data: IQueryRenderModelData;
     len: number;
     state: string;
-    error?: Error;
+    error?: string;
   };
 }
 

--- a/dashboard/src/dashboard-render/model/content.ts
+++ b/dashboard/src/dashboard-render/model/content.ts
@@ -18,7 +18,6 @@ import {
   getInitialQueriesRenderModel,
   getInitialSQLSnippetsRenderModel,
   getInitialViewsRenderModel,
-  type IQueryRenderModelData,
   LayoutsRenderModel,
   MockContextMeta,
   PanelsRenderModel,
@@ -112,15 +111,15 @@ export const ContentRenderModel = types
     getAdditionalQueryInfo(query_id: string): TAdditionalQueryInfo {
       return { content_id: self.id, query_id, params: this.dashboardState };
     },
-    get data(): Record<string, IQueryRenderModelData> {
+    get data(): Record<string, TQueryData> {
       const data = self.queries.current.map(({ id, data }) => ({ id, data }));
       return data.reduce((ret, curr) => {
         ret[curr.id] = curr.data;
         return ret;
-      }, {} as Record<string, IQueryRenderModelData>);
+      }, {} as Record<string, TQueryData>);
     },
     getDataStuffByID(queryID: string): {
-      data: IQueryRenderModelData;
+      data: TQueryData;
       len: number;
       state: string;
       error?: string;

--- a/dashboard/src/dashboard-render/model/index.ts
+++ b/dashboard/src/dashboard-render/model/index.ts
@@ -1,2 +1,3 @@
 export * from './dashboard';
 export * from './content';
+export { type IContentRenderModel } from './types';

--- a/dashboard/src/dashboard-render/model/types.ts
+++ b/dashboard/src/dashboard-render/model/types.ts
@@ -1,0 +1,48 @@
+import { TAdditionalQueryInfo } from '../../api-caller/request';
+import {
+  IFiltersRenderModel,
+  ILayoutsRenderModel,
+  IMockContextMeta,
+  IPanelsRenderModel,
+  IQueriesRenderModel,
+  type IQueryRenderModelData,
+  ISQLSnippetsRenderModel,
+  IViewsRenderModel,
+  TPayloadForSQL,
+  TPayloadForViz,
+} from '../../model';
+import { DashboardContentDBType } from '../../types';
+import { payloadToDashboardState } from '../../utils';
+
+export interface IContentRenderModel {
+  id: string;
+  name: string;
+  dashboard_id: string;
+  create_time: string;
+  update_time: string;
+  version: string;
+  filters: IFiltersRenderModel;
+  queries: IQueriesRenderModel;
+  sqlSnippets: ISQLSnippetsRenderModel;
+  views: IViewsRenderModel;
+  panels: IPanelsRenderModel;
+  layouts: ILayoutsRenderModel;
+  mock_context: IMockContextMeta;
+
+  readonly json: DashboardContentDBType;
+  readonly contentJSON: DashboardContentDBType['content'];
+  readonly payloadForSQL: TPayloadForSQL;
+  readonly payloadForViz: TPayloadForViz;
+  readonly dashboardState: ReturnType<typeof payloadToDashboardState>;
+
+  getAdditionalQueryInfo(query_id: string): TAdditionalQueryInfo;
+
+  readonly data: Record<string, IQueryRenderModelData>;
+
+  getDataStuffByID(queryID: string): {
+    data: IQueryRenderModelData;
+    len: number;
+    state: string;
+    error?: string;
+  };
+}

--- a/dashboard/src/dashboard-render/model/types.ts
+++ b/dashboard/src/dashboard-render/model/types.ts
@@ -5,7 +5,6 @@ import {
   IMockContextMeta,
   IPanelsRenderModel,
   IQueriesRenderModel,
-  type IQueryRenderModelData,
   ISQLSnippetsRenderModel,
   IViewsRenderModel,
   TPayloadForSQL,
@@ -37,10 +36,10 @@ export interface IContentRenderModel {
 
   getAdditionalQueryInfo(query_id: string): TAdditionalQueryInfo;
 
-  readonly data: Record<string, IQueryRenderModelData>;
+  readonly data: Record<string, TQueryData>;
 
   getDataStuffByID(queryID: string): {
-    data: IQueryRenderModelData;
+    data: TQueryData;
     len: number;
     state: string;
     error?: string;

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -25,6 +25,7 @@ export type RenderSearchButtonProps = {
   disabled: boolean;
   onSubmit: OnFiltersSubmit;
 };
+
 export interface IDashboardConfig {
   basename: string;
   apiBaseURL: string;
@@ -35,5 +36,13 @@ export interface IDashboardConfig {
   renderSearchButton?: (props: RenderSearchButtonProps) => ReactNode;
 }
 
-export { notifyVizRendered, onVizRendered, pluginManager } from './components/plugins';
+export {
+  notifyVizRendered,
+  onVizRendered,
+  pluginManager,
+  tokens as pluginServices,
+  useServiceLocator,
+} from './components/plugins';
+export type * from './components/plugins';
+export type { IServiceLocator } from './components/plugins';
 export { type IPanelAddon, type IPanelAddonRenderProps } from './types/plugin';

--- a/dashboard/src/model/meta-model/dashboard/content/filter/filter.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/filter.ts
@@ -237,3 +237,4 @@ export interface IFilterMeta {
 }
 
 typeAssert.shouldExtends<IFilterMeta, FilterMetaInstance>();
+typeAssert.shouldExtends<FilterMetaInstance, IFilterMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/filter/filter.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/filter.ts
@@ -1,14 +1,35 @@
 import _ from 'lodash';
-import { toJS } from 'mobx';
+import { toJS, type IObservableArray } from 'mobx';
 import { Instance, SnapshotOut, getRoot, types } from 'mobx-state-tree';
 import { DashboardFilterType } from './types';
-import { FilterCheckboxConfigMeta, createFilterCheckboxConfig } from './widgets/checkbox';
-import { FilterDateRangeConfigMeta, createFilterDateRangeConfig } from './widgets/date-range';
-import { FilterMultiSelectConfigMeta, createFilterMultiSelectConfig } from './widgets/multi-select';
-import { FilterSelectConfigMeta, createFilterSelectConfig } from './widgets/select';
-import { FilterTextInputConfigMeta, createFilterTextInputConfig } from './widgets/text-input';
-import { FilterTreeSelectConfigMeta, createFilterTreeSelectConfig } from './widgets/tree-select';
-import { createFilterTreeSingleSelectConfig, FilterTreeSingleSelectConfigMeta } from './widgets';
+import { FilterCheckboxConfigMeta, createFilterCheckboxConfig, type IFilterCheckboxConfig } from './widgets/checkbox';
+import {
+  FilterDateRangeConfigMeta,
+  createFilterDateRangeConfig,
+  type IFilterDateRangeConfig,
+} from './widgets/date-range';
+import {
+  FilterMultiSelectConfigMeta,
+  createFilterMultiSelectConfig,
+  type IFilterMultiSelectConfig,
+} from './widgets/multi-select';
+import { FilterSelectConfigMeta, createFilterSelectConfig, type IFilterSelectConfig } from './widgets/select';
+import {
+  FilterTextInputConfigMeta,
+  createFilterTextInputConfig,
+  type IFilterTextInputConfig,
+} from './widgets/text-input';
+import {
+  FilterTreeSelectConfigMeta,
+  createFilterTreeSelectConfig,
+  type IFilterTreeSelectConfig,
+} from './widgets/tree-select';
+import {
+  createFilterTreeSingleSelectConfig,
+  FilterTreeSingleSelectConfigMeta,
+  type IFilterTreeSingleSelectConfig,
+} from './widgets';
+import { typeAssert } from '~/types/utils';
 
 export const FilterMeta = types
   .model('FilterMeta', {
@@ -160,3 +181,59 @@ export const FilterMeta = types
 
 export type FilterMetaInstance = Instance<typeof FilterMeta>;
 export type FilterMetaSnapshotOut = SnapshotOut<FilterMetaInstance>;
+
+export interface IFilterMeta {
+  // Properties
+  id: string;
+  key: string;
+  label: string;
+  order: number;
+  visibleInViewsIDs: IObservableArray<string>;
+  auto_submit: boolean;
+  default_value_func: string;
+  type: DashboardFilterType;
+  config:
+    | IFilterSelectConfig
+    | IFilterMultiSelectConfig
+    | IFilterTreeSelectConfig
+    | IFilterTreeSingleSelectConfig
+    | IFilterTextInputConfig
+    | IFilterCheckboxConfig
+    | IFilterDateRangeConfig;
+
+  // Views
+  readonly contentModel: Record<string, unknown>;
+  readonly filters: Record<string, unknown>;
+  readonly value: unknown;
+  readonly plainDefaultValue: unknown;
+  readonly usingDefaultValue: boolean;
+  readonly usingDefaultValueFunc: boolean;
+  readonly formattedDefaultValue: unknown;
+  readonly auto_submit_supported: boolean;
+  readonly json: {
+    id: string;
+    key: string;
+    type: DashboardFilterType;
+    label: string;
+    order: number;
+    config: Record<string, unknown>;
+    auto_submit: boolean;
+    visibleInViewsIDs: IObservableArray<string>;
+    default_value_func: string;
+  };
+  readonly visibleInViewsIDSet: Set<string>;
+  readonly should_auto_submit: boolean;
+  requiredAndPass(value: unknown): boolean;
+
+  // Actions
+  setKey(key: string): void;
+  setValue(value: unknown): void;
+  setLabel(label: string): void;
+  setOrder(order: number | string): void;
+  setType(type: string | null): void;
+  setVisibleInViewsIDs(ids: string[]): void;
+  setAutoSubmit(v: boolean): void;
+  setDefaultValueFunc(v: string): void;
+}
+
+typeAssert.shouldExtends<IFilterMeta, FilterMetaInstance>();

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/checkbox.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/checkbox.ts
@@ -1,4 +1,5 @@
 import { Instance, types } from 'mobx-state-tree';
+import { typeAssert } from '~/types/utils';
 
 export const FilterCheckboxConfigMeta = types
   .model('FilterCheckboxConfigMeta', {
@@ -30,6 +31,26 @@ export const FilterCheckboxConfigMeta = types
   }));
 
 export type FilterCheckboxConfigInstance = Instance<typeof FilterCheckboxConfigMeta>;
+
+export interface IFilterCheckboxConfig {
+  _name: 'checkbox';
+  description: string;
+  default_value: boolean;
+
+  // Views
+  readonly json: {
+    _name: 'checkbox';
+    description: string;
+    default_value: boolean;
+  };
+  readonly isDescriptionEmpty: boolean;
+
+  // Actions
+  setDefaultValue(default_value: boolean): void;
+  setDescription(v: string): void;
+}
+
+typeAssert.shouldExtends<IFilterCheckboxConfig, FilterCheckboxConfigInstance>();
 
 export const createFilterCheckboxConfig = () =>
   FilterCheckboxConfigMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/date-range.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/date-range.ts
@@ -1,7 +1,8 @@
 import dayjs from 'dayjs';
-
+import { type IObservableArray } from 'mobx';
 import { getParent, Instance, SnapshotOut, types } from 'mobx-state-tree';
 import { getDateRangeShortcutValue } from '~/components/filter/filter-date-range/widget/shortcuts/shortcuts';
+import { typeAssert } from '~/types/utils';
 
 export type DateRangeValue_Value = [Date | null, Date | null];
 export type DateRangeValue = {
@@ -189,6 +190,43 @@ export const FilterDateRangeConfigMeta = types.snapshotProcessor(_FilterDateRang
 });
 
 export type FilterDateRangeConfigInstance = Instance<typeof FilterDateRangeConfigMeta>;
+export interface IFilterDateRangeConfig {
+  // Properties
+  _name: 'date-range';
+  required: boolean;
+  inputFormat: 'YYYY' | 'YYYYMM' | 'YYYYMMDD' | 'YYYY-MM' | 'YYYY-MM-DD';
+  default_value: IObservableArray<Date | null>;
+  default_shortcut: string;
+  clearable: boolean;
+  max_days: number;
+  allowSingleDateInRange: boolean;
+
+  // Views
+  readonly json: {
+    _name: 'date-range';
+    max_days: number;
+    required: boolean;
+    clearable: boolean;
+    inputFormat: 'YYYY' | 'YYYYMM' | 'YYYYMMDD' | 'YYYY-MM' | 'YYYY-MM-DD';
+    default_value: string[];
+    default_shortcut: string;
+    allowSingleDateInRange: boolean;
+  };
+  truthy(fullValue: DateRangeValue): boolean;
+  readonly filter: Record<string, unknown>;
+  readonly dateStringsValue: [string, string];
+
+  // Actions
+  setFilterValue(v: DateRangeValue): void;
+  setRequired(required: boolean): void;
+  setClearable(clearable: boolean): void;
+  setInputFormat(inputFormat: string | null): void;
+  setDefaultValue(v: DateRangeValue): void;
+  setDefaultShortcut(v: string | null): void;
+  setMaxDays(v: number | string): void;
+  setAllowSingleDateInRange(v: boolean): void;
+}
+typeAssert.shouldExtends<IFilterDateRangeConfig, FilterDateRangeConfigInstance>();
 export type FilterDateRangeConfigSnapshotOut = SnapshotOut<typeof FilterDateRangeConfigMeta>;
 
 export const createFilterDateRangeConfig = () =>

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/multi-select.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/multi-select.ts
@@ -1,8 +1,13 @@
-import { reaction, toJS } from 'mobx';
+import { reaction, toJS, type IObservableArray } from 'mobx';
 import { addDisposer, cast, Instance, types } from 'mobx-state-tree';
 import { shallowToJS } from '~/utils';
-import { FilterBaseSelectConfigMeta } from './select-base';
-import { DefaultValueModeModelType } from '../types';
+import {
+  FilterBaseSelectConfigMeta,
+  type IFilterBaseSelectConfigInstance,
+  type IFilterConfigModel_SelectOption,
+} from './select-base';
+import { DefaultValueModeModelType, type DefaultValueMode } from '../types';
+import { typeAssert } from '~/types/utils';
 
 export const FilterMultiSelectConfigMeta = types
   .compose(
@@ -105,6 +110,38 @@ export const FilterMultiSelectConfigMeta = types
   }));
 
 export type FilterMultiSelectConfigInstance = Instance<typeof FilterMultiSelectConfigMeta>;
+
+export interface IFilterMultiSelectConfig extends IFilterBaseSelectConfigInstance {
+  // Properties
+  _name: 'multi-select';
+  default_value: IObservableArray<string>;
+  default_value_mode: 'intersect' | 'reset';
+  min_width: string;
+
+  // Views
+  readonly json: {
+    _name: 'multi-select';
+    required: boolean;
+    min_width: string;
+    default_value: IObservableArray<string>;
+    static_options: IObservableArray<IFilterConfigModel_SelectOption>;
+    options_query_id: string;
+    default_value_mode: DefaultValueMode;
+    default_selection_count: number;
+  };
+  readonly defaultSelection: string[];
+  initialSelection(value: string[] | null): string[];
+  truthy(value: unknown): boolean;
+
+  // Actions
+  setDefaultValue(default_value: string[]): void;
+  setDefaultValueMode(v: string | null): void;
+  setMinWidth(v: string): void;
+  applyDefaultSelection(): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<IFilterMultiSelectConfig, FilterMultiSelectConfigInstance>();
 
 export const createFilterMultiSelectConfig = () =>
   FilterMultiSelectConfigMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/select-base.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/select-base.ts
@@ -1,5 +1,7 @@
 import { ComboboxItem } from '@mantine/core';
-import { Instance, cast, detach, getParent, getRoot, types } from 'mobx-state-tree';
+import type { IObservableArray } from 'mobx';
+import { Instance, detach, getParent, getRoot, types } from 'mobx-state-tree';
+import { typeAssert } from '~/types/utils';
 
 export type TSelectOption = {
   label: string;
@@ -24,6 +26,14 @@ export const FilterConfigModel_SelectOption = types
   }));
 
 export type IFilterSelectConfigMetaOption = Instance<typeof FilterConfigModel_SelectOption>;
+
+export interface IFilterConfigModel_SelectOption {
+  label: string;
+  value: string;
+  setLabel(label: string): void;
+  setValue(value: string): void;
+}
+typeAssert.shouldExtends<IFilterConfigModel_SelectOption, IFilterSelectConfigMetaOption>();
 
 export const FilterBaseSelectConfigMeta = types
   .model('FilterConfigModel_BaseSelect', {
@@ -97,3 +107,35 @@ export const FilterBaseSelectConfigMeta = types
   }));
 
 export type FilterBaseSelectConfigInstance = Instance<typeof FilterBaseSelectConfigMeta>;
+
+export interface IFilterBaseSelectConfigInstance {
+  // Properties
+  static_options: IObservableArray<IFilterConfigModel_SelectOption>;
+  options_query_id: string;
+  default_selection_count: number;
+  required: boolean;
+
+  // todo: improve type
+  // Views
+  readonly contentModel: {
+    getDataStuffByID(id: string): {
+      state: 'loading' | 'error' | 'done';
+      data: TSelectOption[];
+    };
+  };
+  readonly filter: Record<string, unknown>;
+  readonly usingQuery: boolean;
+  readonly optionsLoading: boolean;
+  readonly options: TSelectOption[];
+  readonly optionValuesSet: Set<string>;
+
+  // Actions
+  setRequired(required: boolean): void;
+  addStaticOption(option: StaticOption): void;
+  removeStaticOption(index: number): void;
+  replaceStaticOptions(options: StaticOption[]): void;
+  setDefaultSelectionCount(v: string | number): void;
+  setOptionsQueryID(id: string | null): void;
+}
+
+typeAssert.shouldExtends<IFilterBaseSelectConfigInstance, FilterBaseSelectConfigInstance>();

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/select.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/select.ts
@@ -1,7 +1,13 @@
-import { reaction, toJS } from 'mobx';
+import { reaction, toJS, type IObservableArray } from 'mobx';
 import { addDisposer, Instance, types } from 'mobx-state-tree';
 import { shallowToJS } from '~/utils';
-import { FilterBaseSelectConfigMeta } from './select-base';
+import {
+  FilterBaseSelectConfigMeta,
+  type IFilterBaseSelectConfigInstance,
+  type IFilterConfigModel_SelectOption,
+  type TSelectOption,
+} from './select-base';
+import { typeAssert } from '~/types/utils';
 
 export const FilterSelectConfigMeta = types
   .compose(
@@ -90,6 +96,38 @@ export const FilterSelectConfigMeta = types
   }));
 
 export type FilterSelectConfigInstance = Instance<typeof FilterSelectConfigMeta>;
+
+export interface IFilterSelectConfig extends IFilterBaseSelectConfigInstance {
+  // Properties
+  _name: 'select';
+  default_value: string;
+  width: string;
+  clearable: boolean;
+
+  // Views
+  readonly json: {
+    _name: 'select';
+    width: string;
+    required: boolean;
+    clearable: boolean;
+    default_value: string;
+    static_options: IObservableArray<IFilterConfigModel_SelectOption>;
+    options_query_id: string;
+    default_selection_count: number;
+  };
+  readonly default_selection: string | undefined;
+  truthy(value: unknown): boolean;
+  getSelectOption(value: string): TSelectOption | undefined;
+
+  // Actions
+  setDefaultValue(default_value: string | null): void;
+  setWidth(v: string): void;
+  setClearable(v: boolean): void;
+  setDefaultSelection(): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<IFilterSelectConfig, FilterSelectConfigInstance>();
 
 export const createFilterSelectConfig = () =>
   FilterSelectConfigMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/text-input.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/text-input.ts
@@ -1,4 +1,5 @@
 import { Instance, types } from 'mobx-state-tree';
+import { typeAssert } from '~/types/utils';
 
 export const FilterTextInputConfigMeta = types
   .model('FilterTextInputConfigMeta', {
@@ -32,6 +33,27 @@ export const FilterTextInputConfigMeta = types
   }));
 
 export type FilterTextInputConfigInstance = Instance<typeof FilterTextInputConfigMeta>;
+
+export interface IFilterTextInputConfig {
+  // Properties
+  _name: 'text-input';
+  required: boolean;
+  default_value: string;
+
+  // Views
+  readonly json: {
+    _name: 'text-input';
+    required: boolean;
+    default_value: string;
+  };
+  truthy(value: unknown): boolean;
+
+  // Actions
+  setRequired(required: boolean): void;
+  setDefaultValue(default_value: string): void;
+}
+
+typeAssert.shouldExtends<IFilterTextInputConfig, FilterTextInputConfigInstance>();
 
 export const createFilterTextInputConfig = () =>
   FilterTextInputConfigMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/tree-select-base.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/tree-select-base.ts
@@ -2,8 +2,9 @@ import { Text, TextProps } from '@mantine/core';
 import { Instance, types } from 'mobx-state-tree';
 import React from 'react';
 import { queryDataToTree, ITreeDataQueryOption, ITreeDataRenderItem } from '~/components/filter/filter-tree';
-import { FilterBaseSelectConfigMeta } from './select-base';
+import { FilterBaseSelectConfigMeta, type IFilterBaseSelectConfigInstance } from './select-base';
 import { DefaultValueModeModelType } from '../types';
+import { typeAssert } from '~/types/utils';
 
 function addLabelToData(data: ITreeDataQueryOption[]) {
   return data.map((d) => {
@@ -63,3 +64,20 @@ export const FilterBaseTreeSelectConfigMeta = types
   }));
 
 export type FilterBaseTreeSelectConfigMetaInstance = Instance<typeof FilterBaseTreeSelectConfigMeta>;
+
+export interface IFilterBaseTreeSelectConfigInstance extends IFilterBaseSelectConfigInstance {
+  // Properties
+  min_width: string;
+  default_value_mode: 'intersect' | 'reset';
+
+  // Views
+  readonly plainData: ITreeDataQueryOption[];
+  readonly treeData: ITreeDataRenderItem[];
+  readonly errorMessage: string | undefined;
+  readonly treeDataLoading: boolean;
+
+  // Actions
+  setMinWidth(v: string): void;
+}
+
+typeAssert.shouldExtends<IFilterBaseTreeSelectConfigInstance, FilterBaseTreeSelectConfigMetaInstance>();

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/tree-select.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/tree-select.ts
@@ -1,6 +1,8 @@
-import { reaction } from 'mobx';
+import { reaction, type IObservableArray } from 'mobx';
 import { addDisposer, cast, Instance, types } from 'mobx-state-tree';
-import { FilterBaseTreeSelectConfigMeta } from './tree-select-base';
+import { FilterBaseTreeSelectConfigMeta, type IFilterBaseTreeSelectConfigInstance } from './tree-select-base';
+import { typeAssert } from '~/types/utils';
+import type { IFilterConfigModel_SelectOption } from './select-base';
 
 export const FilterTreeSelectConfigMeta = types
   .compose(
@@ -108,6 +110,41 @@ export const FilterTreeSelectConfigMeta = types
   }));
 
 export type FilterTreeSelectConfigInstance = Instance<typeof FilterTreeSelectConfigMeta>;
+
+export interface IFilterTreeSelectConfigJson {
+  _name: 'tree-select';
+  required: boolean;
+  min_width: string;
+  default_value: IObservableArray<string>;
+  static_options: IObservableArray<IFilterConfigModel_SelectOption>;
+  options_query_id: string;
+  treeCheckStrictly: boolean;
+  default_value_mode: 'intersect' | 'reset';
+  default_selection_count: number;
+}
+
+export interface IFilterTreeSelectConfig extends IFilterBaseTreeSelectConfigInstance {
+  // Properties
+  _name: 'tree-select';
+  default_value: IObservableArray<string>;
+  treeCheckStrictly: boolean;
+
+  // Views
+  readonly json: IFilterTreeSelectConfigJson;
+  readonly defaultSelection: string[];
+  valueObjects(value: string[]): unknown[];
+  initialSelection(value: string[] | null): string[];
+  truthy(value: unknown): boolean;
+
+  // Actions
+  setDefaultValue(default_value: string[]): void;
+  setDefaultValueMode(v: string | null): void;
+  setTreeCheckStrictly(v: boolean): void;
+  applyDefaultSelection(): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<IFilterTreeSelectConfig, FilterTreeSelectConfigInstance>();
 
 export const createFilterTreeSelectConfig = () =>
   FilterTreeSelectConfigMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/filter/widgets/tree-single-select.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/filter/widgets/tree-single-select.ts
@@ -1,6 +1,8 @@
-import { reaction, toJS } from 'mobx';
+import { reaction, toJS, type IObservableArray } from 'mobx';
 import { addDisposer, Instance, types } from 'mobx-state-tree';
-import { FilterBaseTreeSelectConfigMeta } from './tree-select-base';
+import { FilterBaseTreeSelectConfigMeta, type IFilterBaseTreeSelectConfigInstance } from './tree-select-base';
+import { typeAssert } from '~/types/utils';
+import type { IFilterConfigModel_SelectOption } from './select-base';
 
 export const FilterTreeSingleSelectConfigMeta = types
   .compose(
@@ -107,6 +109,37 @@ export const FilterTreeSingleSelectConfigMeta = types
   }));
 
 export type FilterTreeSingleSelectConfigInstance = Instance<typeof FilterTreeSingleSelectConfigMeta>;
+
+export interface IFilterTreeSingleSelectConfig extends IFilterBaseTreeSelectConfigInstance {
+  // Properties
+  _name: 'tree-single-select';
+  default_value: string;
+
+  // Views
+  readonly json: {
+    _name: 'tree-single-select';
+    required: boolean;
+    min_width: string;
+    default_value: string;
+    static_options: IObservableArray<IFilterConfigModel_SelectOption>;
+    options_query_id: string;
+    default_value_mode: 'intersect' | 'reset';
+    default_selection_count: number;
+  };
+  readonly selectFirstByDefault: boolean;
+  readonly defaultSelection: string;
+  valueObject(value: string | null): unknown;
+  initialSelection(value: string | null): string;
+  truthy(value: unknown): boolean;
+
+  // Actions
+  setDefaultValue(default_value: string): void;
+  setDefaultValueMode(v: string | null): void;
+  applyDefaultSelection(): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<IFilterTreeSingleSelectConfig, FilterTreeSingleSelectConfigInstance>();
 
 export const createFilterTreeSingleSelectConfig = () =>
   FilterTreeSingleSelectConfigMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/layout/layout-item.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/layout/layout-item.ts
@@ -1,5 +1,7 @@
 import { Instance, getRoot, types } from 'mobx-state-tree';
 import { Layout } from 'react-grid-layout';
+import type { IPanelRenderModel } from '~/model/render-model';
+import { typeAssert } from '~/types/utils';
 
 export const LayoutItemMeta = types
   .model('LayoutItemMeta', {
@@ -59,6 +61,39 @@ export const LayoutItemMeta = types
   }));
 
 export type LayoutItemMetaInstance = Instance<typeof LayoutItemMeta>;
+
+export interface ILayoutItemMeta {
+  id: string;
+  panelID: string;
+  x: number;
+  y: number | null;
+  w: number;
+  h: number;
+  moved: boolean;
+  static: boolean;
+
+  readonly json: {
+    h: number;
+    w: number;
+    x: number;
+    y: number;
+    id: string;
+    moved: boolean;
+    static: boolean;
+    panelID: string;
+  };
+
+  readonly contentModel: Record<string, unknown>; // FIXME: should move to LayoutItemRenderModel
+  readonly panel: IPanelRenderModel;
+  readonly layoutProperies: Layout;
+
+  set(layout: Omit<Layout, 'i'>): void;
+  setWidth(w: number): void;
+  setHeight(h: number): void;
+}
+
+typeAssert.shouldExtends<ILayoutItemMeta, LayoutItemMetaInstance>();
+typeAssert.shouldExtends<LayoutItemMetaInstance, ILayoutItemMeta>();
 
 export type LayoutItem = {
   id: string;

--- a/dashboard/src/model/meta-model/dashboard/content/layout/layout-item.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/layout/layout-item.ts
@@ -2,6 +2,7 @@ import { Instance, getRoot, types } from 'mobx-state-tree';
 import { Layout } from 'react-grid-layout';
 import type { IPanelRenderModel } from '~/model/render-model';
 import { typeAssert } from '~/types/utils';
+import { IContentRenderModel } from '../../../../../dashboard-render';
 
 export const LayoutItemMeta = types
   .model('LayoutItemMeta', {
@@ -83,7 +84,7 @@ export interface ILayoutItemMeta {
     panelID: string;
   };
 
-  readonly contentModel: Record<string, unknown>; // FIXME: should move to LayoutItemRenderModel
+  readonly contentModel: IContentRenderModel; // FIXME: should move to LayoutItemRenderModel
   readonly panel: IPanelRenderModel;
   readonly layoutProperies: Layout;
 

--- a/dashboard/src/model/meta-model/dashboard/content/layout/layout-set.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/layout/layout-set.ts
@@ -3,6 +3,7 @@ import { IObservableArray } from 'mobx';
 
 import { v4 as uuidv4 } from 'uuid';
 import { shallowToJS } from '~/utils';
+import { IContentRenderModel } from '../../../../../dashboard-render';
 import { LayoutItem, LayoutItemMeta, ILayoutItemMeta } from './layout-item';
 import { Layout } from 'react-grid-layout';
 import _ from 'lodash';
@@ -139,7 +140,7 @@ export interface ILayoutSetMeta {
   breakpoint: number;
   list: IObservableArray<ILayoutItemMeta>;
 
-  readonly contentModel: Record<string, unknown>;
+  readonly contentModel: IContentRenderModel;
   readonly json: {
     id: string;
     name: string;

--- a/dashboard/src/model/meta-model/dashboard/content/layout/layout-set.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/layout/layout-set.ts
@@ -1,12 +1,14 @@
 import { addDisposer, getRoot, Instance, SnapshotIn, SnapshotOut, types } from 'mobx-state-tree';
+import { IObservableArray } from 'mobx';
 
 import { v4 as uuidv4 } from 'uuid';
 import { shallowToJS } from '~/utils';
-import { LayoutItem, LayoutItemMeta } from './layout-item';
+import { LayoutItem, LayoutItemMeta, ILayoutItemMeta } from './layout-item';
 import { Layout } from 'react-grid-layout';
 import _ from 'lodash';
 import { reaction } from 'mobx';
 import { showNotification, updateNotification } from '@mantine/notifications';
+import { typeAssert } from '~/types/utils';
 
 export type LayoutSetInfo = { id: string; name: string; breakpoint: number };
 
@@ -130,3 +132,39 @@ export const LayoutSetMeta = types
 export type LayoutSetMetaInstance = Instance<typeof LayoutSetMeta>;
 export type LayoutSetMetaSnapshotIn = SnapshotIn<LayoutSetMetaInstance>;
 export type LayoutSetMetaSnapshotOut = SnapshotOut<LayoutSetMetaInstance>;
+
+export interface ILayoutSetMeta {
+  id: string;
+  name: string;
+  breakpoint: number;
+  list: IObservableArray<ILayoutItemMeta>;
+
+  readonly contentModel: Record<string, unknown>;
+  readonly json: {
+    id: string;
+    name: string;
+    breakpoint: number;
+    list: Array<ILayoutItemMeta['json']>;
+  };
+
+  jsonByPanelIDSet(panelIDSet: Set<string>): {
+    id: string;
+    name: string;
+    breakpoint: number;
+    list: Array<ILayoutItemMeta['json']>;
+  };
+  findByID(id: string): ILayoutItemMeta | undefined;
+  findByPanelID(panelID: string): ILayoutItemMeta | undefined;
+
+  setName(v: string): void;
+  setBreakpoint(v: number): void;
+  addLayout(layoutItem: LayoutItem): void;
+  addNewLayout(panelID: string): void;
+  removeByPanelID(panelID: string): void;
+  removeByPanelIDs(panelIDs: string[]): void;
+  updateLayoutItem(item: Layout): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<ILayoutSetMeta, LayoutSetMetaInstance>();
+typeAssert.shouldExtends<LayoutSetMetaInstance, ILayoutSetMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/mock-context/mock-context.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/mock-context/mock-context.ts
@@ -1,5 +1,6 @@
-import { types } from 'mobx-state-tree';
+import { types, type Instance } from 'mobx-state-tree';
 import { ContextRecordType } from '~/model';
+import { typeAssert } from '~/types/utils';
 
 export const MockContextMeta = types
   .model('MockContextMeta', {
@@ -39,3 +40,19 @@ export const MockContextMeta = types
 export function getInitialMockContextMeta(context: ContextRecordType) {
   return { current: context };
 }
+
+export interface IMockContextMeta {
+  current: ContextRecordType;
+
+  readonly keys: string[];
+  readonly keySet: Set<string>;
+  readonly entries: Array<[string, ContextRecordType]>;
+
+  replace(record: ContextRecordType): void;
+  defaults(record: ContextRecordType): void;
+  get<T = any>(key: string): T;
+  set<T = any>(key: string, value: T): void;
+}
+
+typeAssert.shouldExtends<Instance<typeof MockContextMeta>, IMockContextMeta>();
+typeAssert.shouldExtends<IMockContextMeta, Instance<typeof MockContextMeta>>();

--- a/dashboard/src/model/meta-model/dashboard/content/panel/panel.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/panel.ts
@@ -1,8 +1,10 @@
-import { cast, types } from 'mobx-state-tree';
-import { PanelStyleMeta } from './style';
-import { PanelTitleMeta } from './title';
-import { VariableMeta, VariableMetaInstance, VariableMetaSnapshotIn } from './variable';
-import { PanelVizMeta } from './viz';
+import { cast, types, type Instance } from 'mobx-state-tree';
+import { type IObservableArray } from 'mobx';
+import { PanelStyleMeta, type IPanelStyleMeta } from './style';
+import { PanelTitleMeta, type IPanelTitleMeta } from './title';
+import { VariableMeta, VariableMetaInstance, VariableMetaSnapshotIn, type IVariableMeta } from './variable';
+import { PanelVizMeta, type IPanelVizMeta } from './viz';
+import { typeAssert } from '~/types/utils';
 
 export const PanelMeta = types
   .model({
@@ -67,3 +69,39 @@ export const PanelMeta = types
       self.variables.remove(variable);
     },
   }));
+
+export interface IPanelMeta {
+  id: string;
+  name: string;
+  title: IPanelTitleMeta;
+  description: string;
+  queryIDs: IObservableArray<string>;
+  viz: IPanelVizMeta;
+  style: IPanelStyleMeta;
+  variables: IObservableArray<IVariableMeta>;
+
+  readonly json: {
+    id: string;
+    viz: IPanelVizMeta['json'];
+    name: string;
+    style: IPanelStyleMeta['json'];
+    title: IPanelTitleMeta['json'];
+    queryIDs: string[];
+    variables: Array<IVariableMeta['json']>;
+    description: string;
+  };
+  readonly queryIDSet: Set<string>;
+
+  setID(id: string): void;
+  setName(name: string): void;
+  setDescription(description: string): void;
+  addQueryID(queryID: string): void;
+  removeQueryID(queryID: string): void;
+  setQueryIDs(queryIDs: string[]): void;
+  addVariable(variable: VariableMetaSnapshotIn): void;
+  removeVariable(variable: VariableMetaInstance): void;
+}
+
+typeAssert.shouldExtends<IPanelMeta, Instance<typeof PanelMeta>>();
+
+typeAssert.shouldExtends<Instance<typeof PanelMeta>, IPanelMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/panel/style/border.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/style/border.ts
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree';
+import { types, Instance } from 'mobx-state-tree';
+import { typeAssert } from '~/types/utils';
 
 export const PanelStyleBorderMeta = types
   .model('PanelStyleBorderMeta', {
@@ -17,3 +18,14 @@ export const PanelStyleBorderMeta = types
       self.enabled = v;
     },
   }));
+
+export interface IPanelStyleBorderMeta {
+  enabled: boolean;
+  json: {
+    enabled: boolean;
+  };
+
+  setEnabled(v: boolean): void;
+}
+
+typeAssert.shouldExtends<IPanelStyleBorderMeta, Instance<typeof PanelStyleBorderMeta>>();

--- a/dashboard/src/model/meta-model/dashboard/content/panel/style/index.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/style/index.ts
@@ -1,5 +1,5 @@
-import { Instance, types } from 'mobx-state-tree';
-import { PanelStyleBorderMeta } from './border';
+import { types } from 'mobx-state-tree';
+import { PanelStyleBorderMeta, type IPanelStyleBorderMeta } from './border';
 
 export const PanelStyleMeta = types
   .model('PanelStyleMeta', {
@@ -14,3 +14,10 @@ export const PanelStyleMeta = types
     },
   }))
   .actions((self) => ({}));
+
+export interface IPanelStyleMeta {
+  border: IPanelStyleBorderMeta;
+  json: {
+    border: IPanelStyleBorderMeta['json'];
+  };
+}

--- a/dashboard/src/model/meta-model/dashboard/content/panel/title.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/title.ts
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree';
+import { types, type Instance } from 'mobx-state-tree';
+import { typeAssert } from '~/types/utils';
 
 export const PanelTitleMeta = types
   .model('PanelTitleMeta', {
@@ -17,3 +18,15 @@ export const PanelTitleMeta = types
       self.show = v;
     },
   }));
+
+export interface IPanelTitleMeta {
+  show: boolean;
+  json: {
+    show: boolean;
+  };
+
+  setShow(v: boolean): void;
+}
+
+typeAssert.shouldExtends<IPanelTitleMeta, Instance<typeof PanelTitleMeta>>();
+typeAssert.shouldExtends<Instance<typeof PanelTitleMeta>, IPanelTitleMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/panel/variable.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/variable.ts
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
+import { type IObservableArray } from 'mobx';
+import { typeAssert } from '~/types/utils';
 
 export const VariableMeta = types
   .model('VariableMeta', {
@@ -65,3 +67,114 @@ export const VariableMeta = types
 export type VariableMetaType = typeof VariableMeta;
 export type VariableMetaSnapshotIn = SnapshotIn<VariableMetaType>;
 export type VariableMetaInstance = Instance<VariableMetaType>;
+
+export interface IVariableMeta {
+  name: string;
+  size: string;
+  weight: string;
+  color:
+    | {
+        type: 'static';
+        staticColor: string;
+      }
+    | {
+        type: 'continuous';
+        valueRange: IObservableArray<number>;
+        colorRange: IObservableArray<string>;
+      }
+    | {
+        type: 'piecewise';
+      };
+  formatter: {
+    output: 'number' | 'percent';
+    average: boolean;
+    mantissa: number;
+    trimMantissa: boolean;
+    absolute: boolean;
+  };
+  data_field: string;
+  aggregation:
+    | {
+        type: 'none' | 'sum' | 'mean' | 'median' | 'min' | 'max' | 'CV' | 'std';
+        config: Record<string, never>;
+        fallback: string;
+      }
+    | {
+        type: 'quantile';
+        config: {
+          p: number;
+        };
+        fallback: string;
+      }
+    | {
+        type: 'pick_record';
+        config: {
+          method: 'first' | 'last';
+        };
+        fallback: string;
+      }
+    | {
+        type: 'custom';
+        config: {
+          func: string;
+        };
+        fallback: string;
+      };
+  readonly json: {
+    name: string;
+    size: string;
+    color:
+      | {
+          type: 'static';
+          staticColor: string;
+        }
+      | {
+          type: 'continuous';
+          valueRange: IObservableArray<number>;
+          colorRange: IObservableArray<string>;
+        }
+      | {
+          type: 'piecewise';
+        };
+    weight: string;
+    formatter: {
+      output: 'number' | 'percent';
+      average: boolean;
+      mantissa: number;
+      trimMantissa: boolean;
+      absolute: boolean;
+    };
+    data_field: string;
+    aggregation:
+      | {
+          type: 'none' | 'sum' | 'mean' | 'median' | 'min' | 'max' | 'CV' | 'std';
+          config: Record<string, never>;
+          fallback: string;
+        }
+      | {
+          type: 'quantile';
+          config: {
+            p: number;
+          };
+          fallback: string;
+        }
+      | {
+          type: 'pick_record';
+          config: {
+            method: 'first' | 'last';
+          };
+          fallback: string;
+        }
+      | {
+          type: 'custom';
+          config: {
+            func: string;
+          };
+          fallback: string;
+        };
+  };
+}
+
+typeAssert.shouldExtends<IVariableMeta, Instance<typeof VariableMeta>>();
+
+typeAssert.shouldExtends<Instance<typeof VariableMeta>, IVariableMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/panel/viz.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/panel/viz.ts
@@ -1,6 +1,7 @@
 import { isEqual } from 'lodash';
-import { types } from 'mobx-state-tree';
+import { types, type Instance } from 'mobx-state-tree';
 import { AnyObject } from '~/types';
+import { typeAssert } from '~/types/utils';
 
 export const PanelVizMeta = types
   .model('PanelVizMeta', {
@@ -24,3 +25,15 @@ export const PanelVizMeta = types
       self.conf = conf;
     },
   }));
+
+export interface IPanelVizMeta {
+  type: string;
+  conf: AnyObject;
+  readonly json: { type: string; conf: AnyObject };
+  setType(type: string): void;
+  setConf(conf: AnyObject): void;
+}
+
+typeAssert.shouldExtends<IPanelVizMeta, Instance<typeof PanelVizMeta>>();
+
+typeAssert.shouldExtends<Instance<typeof PanelVizMeta>, IPanelVizMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/query/db-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/db-query.ts
@@ -4,7 +4,10 @@ import { typeAssert } from '~/types/utils';
 
 export const DBQueryMeta = types
   .model('DBQueryMeta', {
-    _type: types.enumeration([DataSourceType.MySQL, DataSourceType.Postgresql]),
+    _type: types.enumeration<DataSourceType.MySQL | DataSourceType.Postgresql>([
+      DataSourceType.MySQL,
+      DataSourceType.Postgresql,
+    ]),
     sql: types.string,
   })
   .views((self) => ({
@@ -48,6 +51,7 @@ export interface IDBQueryMeta {
 }
 
 typeAssert.shouldExtends<IDBQueryMeta, DBQueryMetaInstance>();
+typeAssert.shouldExtends<DBQueryMetaInstance, IDBQueryMeta>();
 
 export const createDBQueryConfig = (type: DataSourceType.MySQL | DataSourceType.Postgresql) =>
   DBQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/db-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/db-query.ts
@@ -1,5 +1,6 @@
 import { getParent, Instance, SnapshotIn, types } from 'mobx-state-tree';
 import { DataSourceType } from './types';
+import { typeAssert } from '~/types/utils';
 
 export const DBQueryMeta = types
   .model('DBQueryMeta', {
@@ -27,6 +28,26 @@ export const DBQueryMeta = types
   });
 export type DBQueryMetaInstance = Instance<typeof DBQueryMeta>;
 export type DBQueryMetaSnapshotIn = SnapshotIn<DBQueryMetaInstance>;
+
+export interface IDBQueryMeta {
+  // Properties
+  _type: DataSourceType.MySQL | DataSourceType.Postgresql;
+  sql: string;
+
+  // Views
+  // todo: fix root type
+  readonly base: any;
+  readonly valid: boolean;
+  readonly json: {
+    sql: string;
+    _type: DataSourceType.MySQL | DataSourceType.Postgresql;
+  };
+
+  // Actions
+  setSQL(sql: string): void;
+}
+
+typeAssert.shouldExtends<IDBQueryMeta, DBQueryMetaInstance>();
 
 export const createDBQueryConfig = (type: DataSourceType.MySQL | DataSourceType.Postgresql) =>
   DBQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/http-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/http-query.ts
@@ -44,6 +44,7 @@ export interface IHTTPQueryMeta {
 }
 
 typeAssert.shouldExtends<IHTTPQueryMeta, HTTPQueryMetaInstance>();
+typeAssert.shouldExtends<HTTPQueryMetaInstance, IHTTPQueryMeta>();
 
 export const createHTTPQueryConfig = () =>
   HTTPQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/http-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/http-query.ts
@@ -1,6 +1,8 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
+import { type IObservableArray } from 'mobx';
 import { shallowToJS } from '~/utils';
 import { DataSourceType } from './types';
+import { typeAssert } from '~/types/utils';
 
 export const HTTPQueryMeta = types
   .model('HTTPQueryMeta', {
@@ -24,6 +26,24 @@ export const HTTPQueryMeta = types
   }));
 export type HTTPQueryMetaInstance = Instance<typeof HTTPQueryMeta>;
 export type HTTPQueryMetaSnapshotIn = SnapshotIn<HTTPQueryMetaInstance>;
+
+export interface IHTTPQueryMeta {
+  // Properties
+  _type: DataSourceType.HTTP;
+  react_to: IObservableArray<string>;
+
+  // Views
+  readonly valid: boolean;
+  readonly json: {
+    react_to: IObservableArray<string>;
+    _type: DataSourceType.HTTP;
+  };
+
+  // Actions
+  setReactTo(v: string[]): void;
+}
+
+typeAssert.shouldExtends<IHTTPQueryMeta, HTTPQueryMetaInstance>();
 
 export const createHTTPQueryConfig = () =>
   HTTPQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/merico-metric-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/merico-metric-query.ts
@@ -1,6 +1,8 @@
 import { destroy, getParent, Instance, SnapshotIn, types } from 'mobx-state-tree';
 import { shallowToJS } from '~/utils';
 import { DataSourceType } from './types';
+import { typeAssert } from '~/types/utils';
+import type { IObservableArray } from 'mobx';
 
 const MetricFilterColMeta = types
   .model('MetricFilterColMeta', {
@@ -36,6 +38,18 @@ const MetricFilterColMeta = types
   }));
 
 type MetricFilterColMetaInstance = Instance<typeof MetricFilterColMeta>;
+
+export type IMetricFilterColMeta = {
+  dimension: string;
+  variable: string;
+  allEmpty: boolean;
+  json: { dimension: string; variable: string };
+  removeSelf(): void;
+  setDimension(v: string | null): void;
+  setVariable(v: string | null): void;
+};
+
+typeAssert.shouldExtends<IMetricFilterColMeta, MetricFilterColMetaInstance>();
 
 export type MericoMetricType = 'derived' | 'combined';
 
@@ -145,6 +159,59 @@ export const MericoMetricQueryMeta = types
   }));
 export type MericoMetricQueryMetaInstance = Instance<typeof MericoMetricQueryMeta>;
 export type MericoMetricQueryMetaSnapshotIn = SnapshotIn<MericoMetricQueryMetaInstance>;
+
+export interface IMericoMetricQueryMeta {
+  // Properties
+  _type: DataSourceType.MericoMetricSystem;
+  id: string;
+  type: 'derived' | 'combined';
+  filters: IObservableArray<IMetricFilterColMeta>;
+  groupBys: IObservableArray<string>;
+  timeQuery: {
+    enabled: boolean;
+    range_variable: string;
+    unit_variable: string;
+    timezone: string;
+    stepKeyFormat: string;
+  };
+
+  // Views
+  readonly valid: boolean;
+  readonly json: {
+    id: string;
+    type: 'derived' | 'combined';
+    filters: IObservableArray<{
+      dimension: string;
+      variable: string;
+    }>;
+    groupBys: IObservableArray<string>;
+    timeQuery: {
+      enabled: boolean;
+      range_variable: string;
+      unit_variable: string;
+      timezone: string;
+      stepKeyFormat: string;
+    };
+    _type: DataSourceType.MericoMetricSystem;
+  };
+  readonly usedFilterDimensionKeys: Set<string>;
+  readonly usedFilterVariableSet: Set<string>;
+  readonly usedTimeQueryVariableSet: Set<string>;
+  readonly groupByValues: string[];
+
+  // Actions
+  reset(): void;
+  setID(v: string): void;
+  setType(type: string): void;
+  addFilter(k: string, v: string): void;
+  removeFilter(filter: IMetricFilterColMeta): void;
+  setGroupBys(v: string[]): void;
+  setRangeVariable(v: string | null): void;
+  setUnitVariable(v: string | null): void;
+  setTimeQueryEnabled(v: boolean): void;
+}
+
+typeAssert.shouldExtends<IMericoMetricQueryMeta, MericoMetricQueryMetaInstance>();
 
 export const createMericoMetricQueryMetaConfig = () =>
   MericoMetricQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/merico-metric-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/merico-metric-query.ts
@@ -57,7 +57,7 @@ export const MericoMetricQueryMeta = types
   .model('MericoMetricQueryMeta', {
     _type: types.literal(DataSourceType.MericoMetricSystem),
     id: types.optional(types.string, ''),
-    type: types.optional(types.enumeration('MetricType', ['derived', 'combined']), 'derived'),
+    type: types.optional(types.enumeration<MericoMetricType>('MetricType', ['derived', 'combined']), 'derived'),
     filters: types.optional(types.array(MetricFilterColMeta), []),
     groupBys: types.optional(types.array(types.string), []),
     timeQuery: types.model({
@@ -180,7 +180,7 @@ export interface IMericoMetricQueryMeta {
   readonly json: {
     id: string;
     type: 'derived' | 'combined';
-    filters: IObservableArray<{
+    filters: Array<{
       dimension: string;
       variable: string;
     }>;
@@ -212,6 +212,7 @@ export interface IMericoMetricQueryMeta {
 }
 
 typeAssert.shouldExtends<IMericoMetricQueryMeta, MericoMetricQueryMetaInstance>();
+typeAssert.shouldExtends<MericoMetricQueryMetaInstance, IMericoMetricQueryMeta>();
 
 export const createMericoMetricQueryMetaConfig = () =>
   MericoMetricQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/merico-metric-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/merico-metric-query.ts
@@ -3,6 +3,7 @@ import { shallowToJS } from '~/utils';
 import { DataSourceType } from './types';
 import { typeAssert } from '~/types/utils';
 import type { IObservableArray } from 'mobx';
+import { IQueryRenderModel } from '~/model/render-model';
 
 const MetricFilterColMeta = types
   .model('MetricFilterColMeta', {
@@ -176,6 +177,7 @@ export interface IMericoMetricQueryMeta {
   };
 
   // Views
+  readonly query: IQueryRenderModel;
   readonly valid: boolean;
   readonly json: {
     id: string;

--- a/dashboard/src/model/meta-model/dashboard/content/query/query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/query.ts
@@ -100,7 +100,7 @@ export interface IQueryMeta {
     name: string;
     key: string;
     type: DataSourceType;
-    config: IDBQueryMeta | IHTTPQueryMeta | ITransformQueryMeta | IMericoMetricQueryMeta;
+    config: (IDBQueryMeta | IHTTPQueryMeta | ITransformQueryMeta | IMericoMetricQueryMeta)['json'];
     pre_process: string;
     post_process: string;
     run_by: IObservableArray<string>;
@@ -116,3 +116,4 @@ export interface IQueryMeta {
 }
 
 typeAssert.shouldExtends<IQueryMeta, QueryMetaInstance>();
+typeAssert.shouldExtends<QueryMetaInstance, IQueryMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/query/query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/query.ts
@@ -1,11 +1,17 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
-import { createDBQueryConfig, DBQueryMeta } from './db-query';
-import { HTTPQueryMeta, createHTTPQueryConfig } from './http-query';
-import { TransformQueryMeta, createTransformQueryConfig } from './transform-query';
-import { MericoMetricQueryMeta, createMericoMetricQueryMetaConfig } from './merico-metric-query';
+import { type IObservableArray } from 'mobx';
+import { createDBQueryConfig, DBQueryMeta, type IDBQueryMeta } from './db-query';
+import { HTTPQueryMeta, createHTTPQueryConfig, type IHTTPQueryMeta } from './http-query';
+import { TransformQueryMeta, createTransformQueryConfig, type ITransformQueryMeta } from './transform-query';
+import {
+  MericoMetricQueryMeta,
+  createMericoMetricQueryMetaConfig,
+  type IMericoMetricQueryMeta,
+} from './merico-metric-query';
 
 import { DataSourceType } from './types';
 import { shallowToJS } from '~/utils';
+import { typeAssert } from '~/types/utils';
 
 export const QueryMeta = types
   .model('QueryMeta', {
@@ -75,3 +81,38 @@ export const QueryMeta = types
 
 export type QueryMetaInstance = Instance<typeof QueryMeta>;
 export type QueryMetaSnapshotIn = SnapshotIn<QueryMetaInstance>;
+
+export interface IQueryMeta {
+  // Properties
+  id: string;
+  name: string;
+  key: string;
+  type: DataSourceType;
+  config: IDBQueryMeta | IHTTPQueryMeta | ITransformQueryMeta | IMericoMetricQueryMeta;
+  pre_process: string;
+  post_process: string;
+  run_by: IObservableArray<string>;
+
+  // Views
+  readonly valid: boolean;
+  readonly json: {
+    id: string;
+    name: string;
+    key: string;
+    type: DataSourceType;
+    config: IDBQueryMeta | IHTTPQueryMeta | ITransformQueryMeta | IMericoMetricQueryMeta;
+    pre_process: string;
+    post_process: string;
+    run_by: IObservableArray<string>;
+  };
+
+  // Actions
+  setName(name: string): void;
+  setKey(key: string): void;
+  setType(type: DataSourceType): void;
+  setRunBy(v: string[]): void;
+  setPreProcess(v: string): void;
+  setPostProcess(v: string): void;
+}
+
+typeAssert.shouldExtends<IQueryMeta, QueryMetaInstance>();

--- a/dashboard/src/model/meta-model/dashboard/content/query/transform-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/transform-query.ts
@@ -44,6 +44,7 @@ export interface ITransformQueryMeta {
 }
 
 typeAssert.shouldExtends<ITransformQueryMeta, TransformQueryMetaInstance>();
+typeAssert.shouldExtends<TransformQueryMetaInstance, ITransformQueryMeta>();
 
 export const createTransformQueryConfig = () =>
   TransformQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/query/transform-query.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/query/transform-query.ts
@@ -1,6 +1,8 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
 import { shallowToJS } from '~/utils';
 import { DataSourceType } from './types';
+import { typeAssert } from '~/types/utils';
+import type { IObservableArray } from 'mobx';
 
 export const TransformQueryMeta = types
   .model('TransformQueryMeta', {
@@ -24,6 +26,24 @@ export const TransformQueryMeta = types
   }));
 export type TransformQueryMetaInstance = Instance<typeof TransformQueryMeta>;
 export type TransformQueryMetaSnapshotIn = SnapshotIn<TransformQueryMetaInstance>;
+
+export interface ITransformQueryMeta {
+  // Properties
+  _type: DataSourceType.Transform;
+  dep_query_ids: IObservableArray<string>;
+
+  // Views
+  readonly valid: boolean;
+  readonly json: {
+    dep_query_ids: IObservableArray<string>;
+    _type: DataSourceType.Transform;
+  };
+
+  // Actions
+  setDependantQueryIDs(v: string[]): void;
+}
+
+typeAssert.shouldExtends<ITransformQueryMeta, TransformQueryMetaInstance>();
 
 export const createTransformQueryConfig = () =>
   TransformQueryMeta.create({

--- a/dashboard/src/model/meta-model/dashboard/content/sql-snippet/sql-snippet.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/sql-snippet/sql-snippet.ts
@@ -1,4 +1,5 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
+import { typeAssert } from '~/types/utils';
 
 export const SQLSnippetMeta = types
   .model('SQLSnippetMeta', {
@@ -24,3 +25,21 @@ export const SQLSnippetMeta = types
   }));
 
 export type SQLSnippetMetaSnapshotIn = SnapshotIn<Instance<typeof SQLSnippetMeta>>;
+
+export interface ISQLSnippetMeta {
+  // Properties
+  key: string;
+  value: string;
+
+  // Views
+  readonly json: {
+    key: string;
+    value: string;
+  };
+
+  // Actions
+  setKey(key: string): void;
+  setValue(value: string): void;
+}
+
+typeAssert.shouldExtends<ISQLSnippetMeta, Instance<typeof SQLSnippetMeta>>();

--- a/dashboard/src/model/meta-model/dashboard/content/view/view.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/view/view.ts
@@ -1,8 +1,10 @@
 import { Instance, types } from 'mobx-state-tree';
+import { IObservableArray } from 'mobx';
 import { EViewComponentType } from './types';
-import { createViewDivisionConfig, ViewDivisionConfig } from './widgets/division';
-import { createViewModalConfig, ViewModalConfig } from './widgets/modal';
-import { createViewTabsConfig, ViewTabsConfig } from './widgets/tabs';
+import { createViewDivisionConfig, ViewDivisionConfig, type IViewDivisionConfig } from './widgets/division';
+import { createViewModalConfig, ViewModalConfig, type IViewModalConfig } from './widgets/modal';
+import { createViewTabsConfig, ViewTabsConfig, type IViewTabsConfig } from './widgets/tabs';
+import { typeAssert } from '~/types/utils';
 
 export const ViewMeta = types
   .model({
@@ -65,3 +67,31 @@ export const ViewMeta = types
   }));
 
 export type ViewMetaInstance = Instance<typeof ViewMeta>;
+
+export interface IViewMeta {
+  // Properties
+  id: string;
+  name: string;
+  type: EViewComponentType;
+  config: IViewDivisionConfig | IViewModalConfig | IViewTabsConfig;
+  panelIDs: IObservableArray<string>;
+
+  // Views
+  readonly json: {
+    id: string;
+    name: string;
+    type: EViewComponentType;
+    config: IViewDivisionConfig['json'] | IViewModalConfig['json'] | IViewTabsConfig['json'];
+    panelIDs: string[];
+  };
+
+  // Methods
+  setName(name: string): void;
+  setType(type: EViewComponentType): void;
+  appendPanelID(id: string): void;
+  appendPanelIDs(ids: string[]): void;
+  removePanelID(id: string): void;
+}
+
+typeAssert.shouldExtends<IViewMeta, Instance<typeof ViewMeta>>();
+typeAssert.shouldExtends<Instance<typeof ViewMeta>, IViewMeta>();

--- a/dashboard/src/model/meta-model/dashboard/content/view/widgets/division.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/view/widgets/division.ts
@@ -1,5 +1,6 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
 import { EViewComponentType } from '../types';
+import { typeAssert } from '~/types/utils';
 
 export const ViewDivisionConfig = types
   .model('ViewDivisionConfig', {
@@ -21,3 +22,10 @@ export const createViewDivisionConfig = () =>
   ViewDivisionConfig.create({
     _name: EViewComponentType.Division,
   });
+
+export interface IViewDivisionConfig {
+  _name: EViewComponentType.Division;
+  readonly json: { _name: EViewComponentType.Division };
+}
+
+typeAssert.shouldExtends<IViewDivisionConfig, Instance<typeof ViewDivisionConfig>>();

--- a/dashboard/src/model/meta-model/dashboard/content/view/widgets/modal.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/view/widgets/modal.ts
@@ -1,5 +1,6 @@
 import { getParent, getRoot, Instance, SnapshotIn, types } from 'mobx-state-tree';
 import { EViewComponentType, TPayloadForSQLSnippet } from '~/model';
+import { typeAssert } from '~/types/utils';
 
 const CustomModalTitleModel = types
   .model('CustomModalTitleModel', {
@@ -48,6 +49,18 @@ const CustomModalTitleModel = types
     },
   }));
 
+export interface ICustomModalTitleModel {
+  enabled: boolean;
+  func_content: string;
+  readonly json: { enabled: boolean; func_content: string };
+  readonly value: string;
+  setEnabled(v: boolean): void;
+  setFuncContent(v: string): void;
+  replace({ enabled, func_content }: { enabled: boolean; func_content: string }): void;
+}
+
+typeAssert.shouldExtends<ICustomModalTitleModel, Instance<typeof CustomModalTitleModel>>();
+
 export interface ICustomModalTitle {
   enabled: boolean;
   func_content: string;
@@ -89,6 +102,23 @@ export const ViewModalConfig = types
 
 export type ViewModalConfigInstance = Instance<typeof ViewModalConfig>;
 export type ViewModalConfigSnapshotIn = SnapshotIn<ViewModalConfigInstance>;
+
+export interface IViewModalConfig {
+  _name: EViewComponentType.Modal;
+  width: string;
+  height: string;
+  custom_modal_title: ICustomModalTitleModel;
+  readonly json: {
+    _name: EViewComponentType.Modal;
+    width: string;
+    height: string;
+    custom_modal_title: { enabled: boolean; func_content: string };
+  };
+  setWidth(v: string): void;
+  setHeight(v: string): void;
+}
+
+typeAssert.shouldExtends<IViewModalConfig, Instance<typeof ViewModalConfig>>();
 
 export const createViewModalConfig = () =>
   ViewModalConfig.create({

--- a/dashboard/src/model/meta-model/dashboard/content/view/widgets/tabs.ts
+++ b/dashboard/src/model/meta-model/dashboard/content/view/widgets/tabs.ts
@@ -3,6 +3,8 @@ import { randomId } from '@mantine/hooks';
 import { cast, Instance, SnapshotIn, types } from 'mobx-state-tree';
 import { EViewComponentType } from '../types';
 import _ from 'lodash';
+import { typeAssert } from '~/types/utils';
+import type { IObservableArray } from 'mobx';
 
 export type TabInfo = { id: string; name: string };
 export type TabsOrientation = 'vertical' | 'horizontal';
@@ -51,6 +53,22 @@ const TabModel = types
 
 export type TabModelInstance = Instance<typeof TabModel>;
 type TabModelSnapshotIn = SnapshotIn<TabModelInstance>;
+
+export interface ITabModel {
+  id: string;
+  name: string;
+  view_id: string;
+  color: string;
+  order: number;
+  readonly json: { id: string; name: string; color: string; order: number; view_id: string };
+  setName(v: string): void;
+  setViewID(v: string | null): void;
+  setColor(v: string): void;
+  setOrder(v: string | number): void;
+}
+
+typeAssert.shouldExtends<ITabModel, Instance<typeof TabModel>>();
+typeAssert.shouldExtends<Instance<typeof TabModel>, ITabModel>();
 
 export const ViewTabsConfig = types
   .model('ViewTabsConfig', {
@@ -114,6 +132,44 @@ export const ViewTabsConfig = types
 
 export type ViewTabsConfigInstance = Instance<typeof ViewTabsConfig>;
 export type ViewTabsConfigSnapshotIn = SnapshotIn<ViewTabsConfigInstance>;
+
+export interface IViewTabsConfig {
+  // Properties
+  _name: EViewComponentType.Modal;
+  tabs: IObservableArray<ITabModel>;
+  variant: TabsVariant;
+  orientation: TabsOrientation;
+  grow: boolean;
+
+  // Views
+  readonly json: {
+    _name: EViewComponentType.Modal;
+    tabs: Array<ITabModel['json']>;
+    variant: TabsVariant;
+    orientation: TabsOrientation;
+    grow: boolean;
+  };
+  readonly tabsInOrder: ITabModel[];
+
+  // Methods
+  setVariant(v: string | null): void;
+  setOrientation(v: string | null): void;
+  setGrow(v: boolean): void;
+  setTabs(
+    v: Array<{
+      id: string;
+      name: string;
+      view_id: string;
+      color?: string;
+      order?: number;
+    }>,
+  ): void;
+  addTab(): void;
+  removeTab(index: number): void;
+}
+
+typeAssert.shouldExtends<IViewTabsConfig, Instance<typeof ViewTabsConfig>>();
+typeAssert.shouldExtends<Instance<typeof ViewTabsConfig>, IViewTabsConfig>();
 
 export const createViewTabsConfig = () =>
   ViewTabsConfig.create({

--- a/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
+++ b/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
@@ -14,6 +14,7 @@ import { downloadJSON } from '~/utils/download';
 import { getValuesFromFilters, formatInputFilterValues } from './utils';
 import { typeAssert } from '~/types/utils';
 import type { TSelectOption } from '~/model/meta-model/dashboard/content/filter/widgets/select-base';
+import { IContentRenderModel } from '~/dashboard-render';
 
 export const FiltersRenderModel = types
   .model('FiltersRenderModel', {
@@ -199,7 +200,7 @@ export interface IFiltersRenderModel {
   readonly valuesString: string;
   readonly filter: unknown;
   readonly valuesForPayload: Record<string, unknown>;
-  readonly contentModel: unknown;
+  readonly contentModel: IContentRenderModel;
   readonly context: ContextRecordType;
   readonly initialValuesDep: string;
   readonly formattedDefaultValues: Record<string, unknown>;

--- a/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
+++ b/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
@@ -131,11 +131,20 @@ export const FiltersRenderModel = types
       return self.values[key];
     },
 
-    getSchema(ids: string[], raw?: boolean) {
+    getSchema(
+      ids: string[],
+      raw?: boolean,
+    ): {
+      filters: IFilterSchemaItem[];
+      version: string;
+    } {
       const filters = self.findByIDSet(new Set(ids));
 
       const ret = {
-        filters: filters.map((f) => ({ ...f.json, visibleInViewsIDs: raw ? f.json.visibleInViewsIDs : [] })),
+        filters: filters.map((f) => ({
+          ...f.json,
+          visibleInViewsIDs: raw ? f.json.visibleInViewsIDs : ([] as string[]),
+        })),
         version: CURRENT_SCHEMA_VERSION,
       };
       return ret;
@@ -175,6 +184,10 @@ export interface IFilterJsonType {
   default_value_func: string;
 }
 
+export interface IFilterSchemaItem extends Omit<IFilterJsonType, 'visibleInViewsIDs'> {
+  visibleInViewsIDs: string[];
+}
+
 export interface IFiltersRenderModel {
   // Properties
   current: IObservableArray<IFilterMeta>;
@@ -203,7 +216,7 @@ export interface IFiltersRenderModel {
   readonly firstFilterValueKey: string;
   getSelectOption(id: string): Record<string, unknown>;
 
-  // Actions
+  // ActionvisibleInViewsIDss
   setValues(values: Record<string, unknown>): void;
   patchValues(values: FilterValuesType): void;
   setValueByKey(key: string, value: unknown): void;
@@ -213,10 +226,11 @@ export interface IFiltersRenderModel {
     ids: string[],
     raw?: boolean,
   ): {
-    filters: IFilterJsonType[];
+    filters: IFilterSchemaItem[];
     version: string;
   };
   downloadSchema(ids: string[]): void;
 }
 
 typeAssert.shouldExtends<IFiltersRenderModel, FiltersRenderModelInstance>();
+typeAssert.shouldExtends<FiltersRenderModelInstance, IFiltersRenderModel>();

--- a/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
+++ b/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
@@ -13,6 +13,7 @@ import {
 import { downloadJSON } from '~/utils/download';
 import { getValuesFromFilters, formatInputFilterValues } from './utils';
 import { typeAssert } from '~/types/utils';
+import type { TSelectOption } from '~/model/meta-model/dashboard/content/filter/widgets/select-base';
 
 export const FiltersRenderModel = types
   .model('FiltersRenderModel', {
@@ -96,7 +97,7 @@ export const FiltersRenderModel = types
       }, {} as Record<string, string>);
     },
     getSelectOption(id: string) {
-      const filter = this.findByID(id);
+      const filter = this.findByID(id) as IFilterMeta | undefined;
       if (!filter || !('getSelectOption' in filter.config)) {
         return null;
       }
@@ -214,7 +215,7 @@ export interface IFiltersRenderModel {
   readonly inOrder: IFilterMeta[];
   visibleInView(viewID: string): IFilterMeta[];
   readonly firstFilterValueKey: string;
-  getSelectOption(id: string): Record<string, unknown>;
+  getSelectOption(id: string): TSelectOption | null | undefined;
 
   // ActionvisibleInViewsIDss
   setValues(values: Record<string, unknown>): void;

--- a/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
+++ b/dashboard/src/model/render-model/dashboard/content/filters/filters.ts
@@ -1,14 +1,18 @@
 import _ from 'lodash';
 import { Instance, getParent, getRoot, types } from 'mobx-state-tree';
+import { type IObservableArray } from 'mobx';
 import {
   CURRENT_SCHEMA_VERSION,
   ContextRecordType,
   FilterMeta,
   FilterMetaSnapshotOut,
   FilterValuesType,
+  type DashboardFilterType,
+  type IFilterMeta,
 } from '~/model';
 import { downloadJSON } from '~/utils/download';
 import { getValuesFromFilters, formatInputFilterValues } from './utils';
+import { typeAssert } from '~/types/utils';
 
 export const FiltersRenderModel = types
   .model('FiltersRenderModel', {
@@ -158,3 +162,61 @@ export function getInitialFiltersConfig(
     values: initialValues,
   };
 }
+
+export interface IFilterJsonType {
+  id: string;
+  key: string;
+  type: DashboardFilterType;
+  label: string;
+  order: number;
+  config: Record<string, unknown>;
+  auto_submit: boolean;
+  visibleInViewsIDs: IObservableArray<string>;
+  default_value_func: string;
+}
+
+export interface IFiltersRenderModel {
+  // Properties
+  current: IObservableArray<IFilterMeta>;
+  values: Record<string, unknown>;
+
+  // Views
+  readonly json: IFilterJsonType[];
+  readonly valuesString: string;
+  readonly filter: unknown;
+  readonly valuesForPayload: Record<string, unknown>;
+  readonly contentModel: unknown;
+  readonly context: ContextRecordType;
+  readonly initialValuesDep: string;
+  readonly formattedDefaultValues: Record<string, unknown>;
+  readonly firstID: string | undefined;
+  readonly keySet: Set<string>;
+  readonly keyLabelMap: Record<string, string>;
+  readonly empty: boolean;
+
+  // Methods
+  findByID(id: string): IFilterMeta | undefined;
+  findByKey(key: string): IFilterMeta | undefined;
+  findByIDSet(idset: Set<string>): IFilterMeta[];
+  readonly inOrder: IFilterMeta[];
+  visibleInView(viewID: string): IFilterMeta[];
+  readonly firstFilterValueKey: string;
+  getSelectOption(id: string): Record<string, unknown>;
+
+  // Actions
+  setValues(values: Record<string, unknown>): void;
+  patchValues(values: FilterValuesType): void;
+  setValueByKey(key: string, value: unknown): void;
+  applyValuesPatch(values: Record<string, unknown>): void;
+  getValueByKey(key: string): unknown;
+  getSchema(
+    ids: string[],
+    raw?: boolean,
+  ): {
+    filters: IFilterJsonType[];
+    version: string;
+  };
+  downloadSchema(ids: string[]): void;
+}
+
+typeAssert.shouldExtends<IFiltersRenderModel, FiltersRenderModelInstance>();

--- a/dashboard/src/model/render-model/dashboard/content/layouts/layouts.ts
+++ b/dashboard/src/model/render-model/dashboard/content/layouts/layouts.ts
@@ -1,7 +1,13 @@
 import { IObservableArray, reaction } from 'mobx';
 import { Instance, addDisposer, getRoot, types, IAnyStateTreeNode } from 'mobx-state-tree';
 import { Layout } from 'react-grid-layout';
-import { LayoutItemMetaInstance, LayoutSetMeta, LayoutSetMetaInstance, ILayoutSetMeta } from '~/model/meta-model';
+import {
+  LayoutItemMetaInstance,
+  LayoutSetMeta,
+  LayoutSetMetaInstance,
+  ILayoutSetMeta,
+  ILayoutItemMeta,
+} from '~/model/meta-model';
 import { typeAssert } from '~/types/utils';
 import { IContentRenderModel } from '../../../../../dashboard-render';
 
@@ -187,7 +193,7 @@ export interface ILayoutsRenderModel {
   }>;
   readonly currentBreakpointRange: ILayoutBreakPointRange | undefined;
   readonly currentLayoutPreviewWidth: number | undefined;
-  items(panelIDs: string[]): Array<LayoutItemMetaInstance>;
+  items(panelIDs: string[]): Array<ILayoutItemMeta>;
   gridLayouts(panelIDs: string[]): Record<string, Layout[]>;
   findItemByPanelID(panelID: string): LayoutItemMetaInstance;
 

--- a/dashboard/src/model/render-model/dashboard/content/layouts/layouts.ts
+++ b/dashboard/src/model/render-model/dashboard/content/layouts/layouts.ts
@@ -3,6 +3,7 @@ import { Instance, addDisposer, getRoot, types, IAnyStateTreeNode } from 'mobx-s
 import { Layout } from 'react-grid-layout';
 import { LayoutItemMetaInstance, LayoutSetMeta, LayoutSetMetaInstance, ILayoutSetMeta } from '~/model/meta-model';
 import { typeAssert } from '~/types/utils';
+import { IContentRenderModel } from '../../../../../dashboard-render';
 
 function getRangeText({ min, max }: any) {
   const _min = `${min}px`;
@@ -170,7 +171,7 @@ export interface ILayoutsRenderModel {
   readonly json: Array<ILayoutSetMeta['json']>;
   jsonByPanelIDSet(panelIDSet: Set<string>): Array<ILayoutSetMeta['json']>;
   readonly root: IAnyStateTreeNode;
-  readonly contentModel: Record<string, unknown>;
+  readonly contentModel: IContentRenderModel;
   readonly basisLayoutSet: ILayoutSetMeta;
   readonly currentLayoutSet: ILayoutSetMeta;
   readonly currentLayoutRange: ILayoutBreakPointRange;

--- a/dashboard/src/model/render-model/dashboard/content/layouts/layouts.ts
+++ b/dashboard/src/model/render-model/dashboard/content/layouts/layouts.ts
@@ -1,7 +1,8 @@
-import { reaction } from 'mobx';
-import { Instance, addDisposer, getRoot, types } from 'mobx-state-tree';
+import { IObservableArray, reaction } from 'mobx';
+import { Instance, addDisposer, getRoot, types, IAnyStateTreeNode } from 'mobx-state-tree';
 import { Layout } from 'react-grid-layout';
-import { LayoutItemMetaInstance, LayoutSetMeta, LayoutSetMetaInstance } from '~/model/meta-model';
+import { LayoutItemMetaInstance, LayoutSetMeta, LayoutSetMetaInstance, ILayoutSetMeta } from '~/model/meta-model';
+import { typeAssert } from '~/types/utils';
 
 function getRangeText({ min, max }: any) {
   const _min = `${min}px`;
@@ -153,3 +154,46 @@ export const LayoutsRenderModel = types
   }));
 
 export type LayoutsRenderModelInstance = Instance<typeof LayoutsRenderModel>;
+
+export interface ILayoutBreakPointRange {
+  id: string;
+  name: string;
+  min: number;
+  max: number;
+  text: string;
+}
+
+export interface ILayoutsRenderModel {
+  list: IObservableArray<ILayoutSetMeta>;
+  currentBreakpoint: string;
+
+  readonly json: Array<ILayoutSetMeta['json']>;
+  jsonByPanelIDSet(panelIDSet: Set<string>): Array<ILayoutSetMeta['json']>;
+  readonly root: IAnyStateTreeNode;
+  readonly contentModel: Record<string, unknown>;
+  readonly basisLayoutSet: ILayoutSetMeta;
+  readonly currentLayoutSet: ILayoutSetMeta;
+  readonly currentLayoutRange: ILayoutBreakPointRange;
+  readonly currentRangeText: string;
+  readonly cols: Record<string, 36>;
+  readonly breakpoints: Record<string, number>;
+  readonly breakpointNameRecord: Record<string, number>;
+  readonly breakpointRanges: Array<ILayoutBreakPointRange>;
+  readonly breakpointsInfo: Array<{
+    id: string;
+    name: string;
+    breakpoint: number;
+  }>;
+  readonly currentBreakpointRange: ILayoutBreakPointRange | undefined;
+  readonly currentLayoutPreviewWidth: number | undefined;
+  items(panelIDs: string[]): Array<LayoutItemMetaInstance>;
+  gridLayouts(panelIDs: string[]): Record<string, Layout[]>;
+  findItemByPanelID(panelID: string): LayoutItemMetaInstance;
+
+  setCurrentBreakpoint(b: string): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<ILayoutsRenderModel, Instance<typeof LayoutsRenderModel>>();
+
+typeAssert.shouldExtends<Instance<typeof LayoutsRenderModel>, ILayoutsRenderModel>();

--- a/dashboard/src/model/render-model/dashboard/content/panels/index.ts
+++ b/dashboard/src/model/render-model/dashboard/content/panels/index.ts
@@ -1,2 +1,3 @@
 export * from './panel';
 export * from './panels';
+export * from './types';

--- a/dashboard/src/model/render-model/dashboard/content/panels/panel.ts
+++ b/dashboard/src/model/render-model/dashboard/content/panels/panel.ts
@@ -1,22 +1,8 @@
-import _ from 'lodash';
-import {
-  getRoot,
-  Instance,
-  SnapshotIn,
-  IMSTArray,
-  ISimpleType,
-  IStateTreeNode,
-  IOptionalIType,
-  IArrayType,
-} from 'mobx-state-tree';
-import { type ReactNode } from 'react';
+import { getRoot, Instance, SnapshotIn } from 'mobx-state-tree';
 import { TableVizComponent } from '~/components/plugins/viz-components/table';
-import { PanelMeta, type IPanelMeta } from '~/model/meta-model/dashboard/content/panel';
-import { type IPanelStyleMeta } from '~/model/meta-model/dashboard/content/panel/style';
-import { type IPanelTitleMeta } from '~/model/meta-model/dashboard/content/panel/title';
-import { type IVariableMeta } from '~/model/meta-model/dashboard/content/panel/variable';
-import { QueryRenderModelInstance, type IQueryRenderModel } from '../queries';
-import { downloadJSON } from '~/utils/download';
+import { CURRENT_SCHEMA_VERSION } from '~/model/meta-model';
+import { PanelMeta } from '~/model/meta-model/dashboard/content/panel';
+import { typeAssert } from '~/types/utils';
 import {
   formatAggregatedValue,
   getAggregatedValue,
@@ -24,9 +10,9 @@ import {
   ITemplateVariable,
   variablesToStrings,
 } from '~/utils';
-import { CURRENT_SCHEMA_VERSION, type IQueryMeta } from '~/model/meta-model';
-import { typeAssert } from '~/types/utils';
-import { DataSourceType } from '~/model/meta-model/dashboard/content/query/types';
+import { downloadJSON } from '~/utils/download';
+import { QueryRenderModelInstance } from '../queries';
+import { IPanelRenderModel } from './types';
 
 export type VariableValueMap = Record<string, string | number>;
 export type VariableAggValueMap = Record<string, string | number>;
@@ -191,38 +177,6 @@ export function getNewPanel(id: string): PanelRenderModelSnapshotIn {
       },
     },
   };
-}
-
-export interface IPanelRenderModel extends IPanelMeta {
-  readonly contentModel: {
-    content: {
-      queries: {
-        findByIDSet(ids: Set<string>): QueryRenderModelInstance[];
-      };
-    };
-  };
-  readonly queries: QueryRenderModelInstance[];
-  readonly firstQuery: QueryRenderModelInstance | null;
-  readonly firstQueryData: Array<string[] | number[] | Record<string, unknown>>;
-  readonly data: TPanelData;
-  readonly variableStrings: Record<string, ReactNode>;
-  readonly variableAggValueMap: VariableAggValueMap;
-  readonly variableValueMap: VariableValueMap;
-  readonly variableStyleMap: VariableStyleMap;
-  readonly dataLoading: boolean;
-  readonly queryStateMessages: string;
-  readonly queryErrors: string[];
-  readonly canRenderViz: boolean;
-
-  queryByID(queryID: string): IQueryRenderModel | undefined;
-  refreshData(): void;
-  downloadData(): void;
-  getSchema(): {
-    panel: IPanelMeta['json'];
-    queries: Array<IQueryRenderModel['json']>;
-    layouts: unknown;
-  };
-  downloadSchema(): void;
 }
 
 typeAssert.shouldExtends<IPanelRenderModel, Instance<typeof PanelRenderModel>>();

--- a/dashboard/src/model/render-model/dashboard/content/panels/panels.ts
+++ b/dashboard/src/model/render-model/dashboard/content/panels/panels.ts
@@ -1,7 +1,7 @@
 import { Instance, types } from 'mobx-state-tree';
-import { PanelRenderModel, PanelRenderModelInstance, type IPanelRenderModel } from './panel';
 import { typeAssert } from '~/types/utils';
-import type { IObservableArray } from 'mobx';
+import { PanelRenderModel, PanelRenderModelInstance } from './panel';
+import { IPanelsRenderModel } from './types';
 
 export const PanelsRenderModel = types
   .model('PanelsRenderModel', {
@@ -38,14 +38,6 @@ export const PanelsRenderModel = types
   }));
 
 export type PanelsRenderModelInstance = Instance<typeof PanelsRenderModel>;
-
-export interface IPanelsRenderModel {
-  list: IObservableArray<IPanelRenderModel>;
-  readonly json: IPanelRenderModel['json'][];
-  findByID<T = IPanelRenderModel>(id: string): T | undefined;
-  readonly idMap: Map<string, IPanelRenderModel>;
-  panelsByIDs(ids: string[]): IPanelRenderModel[];
-}
 
 typeAssert.shouldExtends<IPanelsRenderModel, Instance<typeof PanelsRenderModel>>();
 typeAssert.shouldExtends<Instance<typeof PanelsRenderModel>, IPanelsRenderModel>();

--- a/dashboard/src/model/render-model/dashboard/content/panels/panels.ts
+++ b/dashboard/src/model/render-model/dashboard/content/panels/panels.ts
@@ -1,5 +1,7 @@
 import { Instance, types } from 'mobx-state-tree';
-import { PanelRenderModel, PanelRenderModelInstance } from './panel';
+import { PanelRenderModel, PanelRenderModelInstance, type IPanelRenderModel } from './panel';
+import { typeAssert } from '~/types/utils';
+import type { IObservableArray } from 'mobx';
 
 export const PanelsRenderModel = types
   .model('PanelsRenderModel', {
@@ -36,3 +38,14 @@ export const PanelsRenderModel = types
   }));
 
 export type PanelsRenderModelInstance = Instance<typeof PanelsRenderModel>;
+
+export interface IPanelsRenderModel {
+  list: IObservableArray<IPanelRenderModel>;
+  readonly json: IPanelRenderModel['json'][];
+  findByID<T = IPanelRenderModel>(id: string): T | undefined;
+  readonly idMap: Map<string, IPanelRenderModel>;
+  panelsByIDs(ids: string[]): IPanelRenderModel[];
+}
+
+typeAssert.shouldExtends<IPanelsRenderModel, Instance<typeof PanelsRenderModel>>();
+typeAssert.shouldExtends<Instance<typeof PanelsRenderModel>, IPanelsRenderModel>();

--- a/dashboard/src/model/render-model/dashboard/content/panels/types.ts
+++ b/dashboard/src/model/render-model/dashboard/content/panels/types.ts
@@ -1,17 +1,12 @@
 import type { IObservableArray } from 'mobx';
 import type { ReactNode } from 'react';
+import { IContentRenderModel } from '../../../../../dashboard-render';
 import type { IPanelMeta } from '../../../../meta-model';
 import { type IQueryRenderModel, QueryRenderModelInstance } from '../queries';
 import { VariableAggValueMap, VariableStyleMap, VariableValueMap } from './panel';
 
 export interface IPanelRenderModel extends IPanelMeta {
-  readonly contentModel: {
-    content: {
-      queries: {
-        findByIDSet(ids: Set<string>): QueryRenderModelInstance[];
-      };
-    };
-  };
+  readonly contentModel: IContentRenderModel;
   readonly queries: QueryRenderModelInstance[];
   readonly firstQuery: QueryRenderModelInstance | null;
   readonly firstQueryData: Array<string[] | number[] | Record<string, unknown>>;

--- a/dashboard/src/model/render-model/dashboard/content/panels/types.ts
+++ b/dashboard/src/model/render-model/dashboard/content/panels/types.ts
@@ -1,0 +1,52 @@
+import type { IObservableArray } from 'mobx';
+import type { ReactNode } from 'react';
+import type { IPanelMeta } from '../../../../meta-model';
+import { type IQueryRenderModel, QueryRenderModelInstance } from '../queries';
+import { VariableAggValueMap, VariableStyleMap, VariableValueMap } from './panel';
+
+export interface IPanelRenderModel extends IPanelMeta {
+  readonly contentModel: {
+    content: {
+      queries: {
+        findByIDSet(ids: Set<string>): QueryRenderModelInstance[];
+      };
+    };
+  };
+  readonly queries: QueryRenderModelInstance[];
+  readonly firstQuery: QueryRenderModelInstance | null;
+  readonly firstQueryData: Array<string[] | number[] | Record<string, unknown>>;
+  readonly data: TPanelData;
+  readonly variableStrings: Record<string, ReactNode>;
+  readonly variableAggValueMap: VariableAggValueMap;
+  readonly variableValueMap: VariableValueMap;
+  readonly variableStyleMap: VariableStyleMap;
+  readonly dataLoading: boolean;
+  readonly queryStateMessages: string;
+  readonly queryErrors: string[];
+  readonly canRenderViz: boolean;
+
+  queryByID(queryID: string): IQueryRenderModel | undefined;
+
+  refreshData(): void;
+
+  downloadData(): void;
+
+  getSchema(): {
+    panel: IPanelMeta['json'];
+    queries: Array<IQueryRenderModel['json']>;
+    layouts: unknown;
+  };
+
+  downloadSchema(): void;
+}
+
+export interface IPanelsRenderModel {
+  list: IObservableArray<IPanelRenderModel>;
+  readonly json: IPanelRenderModel['json'][];
+
+  findByID<T = IPanelRenderModel>(id: string): T | undefined;
+
+  readonly idMap: Map<string, IPanelRenderModel>;
+
+  panelsByIDs(ids: string[]): IPanelRenderModel[];
+}

--- a/dashboard/src/model/render-model/dashboard/content/queries/mute-query.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/mute-query.ts
@@ -8,7 +8,9 @@ import {
   MericoMetricQueryMetaInstance,
   MericoMetricType,
   QueryMeta,
+  type IQueryMeta,
 } from '~/model';
+import { typeAssert } from '~/types/utils';
 import { explainHTTPRequest } from '~/utils';
 import { explainSQL } from '~/utils';
 import { DependencyInfo, UsageRegs } from '~/utils';
@@ -333,3 +335,47 @@ export const MuteQueryModel = QueryMeta.views((self) => ({
 }));
 
 export type MuteQueryModelInstance = Instance<typeof MuteQueryModel>;
+
+export interface IMuteQueryModel extends IQueryMeta {
+  // Views
+  readonly rootModel: Record<string, unknown>;
+  readonly contentModel: Record<string, unknown>;
+  readonly conditionOptions: {
+    optionGroups: Array<ComboboxItemGroup<ComboboxItem>>;
+    validValues: Set<string>;
+  };
+  readonly payload: Record<string, unknown>;
+  readonly formattedSQL: string;
+  readonly httpConfigString: string;
+  readonly typedAsSQL: boolean;
+  readonly typedAsHTTP: boolean;
+  readonly isMericoMetricQuery: boolean;
+  readonly isTransform: boolean;
+  readonly reQueryKey: string;
+  readonly runByConditionsMet: boolean;
+  readonly conditionNames: {
+    context: string[];
+    filters: string[];
+  };
+  readonly queries: string[];
+  readonly inUse: boolean;
+  readonly dependencies: DependencyInfo[];
+  readonly metricQueryPayload: MetricQueryPayload | null;
+  readonly metricQueryPayloadString: string;
+  readonly metricQueryPayloadError: string[];
+  readonly metricQueryPayloadErrorString: string;
+  readonly metricQueryPayloadValid: boolean;
+  readonly unmetRunByConditions: string[];
+  readonly conditionOptionsWithInvalidRunbys: {
+    optionGroups: Array<ComboboxItemGroup<ComboboxItem>>;
+    validValues: Set<string>;
+  };
+
+  // Methods
+  getConditionOptionsWithInvalidValue(value: string | null): {
+    optionGroups: Array<ComboboxItemGroup<ComboboxItem>>;
+    validValues: Set<string>;
+  };
+}
+
+typeAssert.shouldExtends<IMuteQueryModel, MuteQueryModelInstance>();

--- a/dashboard/src/model/render-model/dashboard/content/queries/mute-query.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/mute-query.ts
@@ -37,7 +37,7 @@ export const MuteQueryModel = QueryMeta.views((self) => ({
   get contentModel(): any {
     return this.rootModel.content; // dashboard content model
   },
-  get conditionOptions() {
+  get conditionOptions(): { optionGroups: Array<ComboboxItemGroup<ComboboxItem>>; validValues: Set<string> } {
     if (!isAlive(self)) {
       return { optionGroups: [], validValues: new Set() };
     }
@@ -97,9 +97,12 @@ export const MuteQueryModel = QueryMeta.views((self) => ({
       validValues,
     };
   },
-  get conditionOptionsWithInvalidRunbys() {
+  get conditionOptionsWithInvalidRunbys(): {
+    optionGroups: Array<ComboboxItemGroup<ComboboxItem>>;
+    validValues: Set<string>;
+  } {
     const { optionGroups, validValues } = this.conditionOptions;
-    const invalidGroup: ComboboxItemGroup = {
+    const invalidGroup: ComboboxItemGroup<ComboboxItem> = {
       group: 'common.invalid',
       items: [],
     };
@@ -379,3 +382,4 @@ export interface IMuteQueryModel extends IQueryMeta {
 }
 
 typeAssert.shouldExtends<IMuteQueryModel, MuteQueryModelInstance>();
+typeAssert.shouldExtends<MuteQueryModelInstance, IMuteQueryModel>();

--- a/dashboard/src/model/render-model/dashboard/content/queries/mute-query.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/mute-query.ts
@@ -2,6 +2,7 @@ import { ComboboxItem, ComboboxItemGroup } from '@mantine/core';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { getParent, getRoot, Instance, isAlive } from 'mobx-state-tree';
+import { IContentRenderModel } from '~/dashboard-render';
 import {
   DashboardFilterType,
   DataSourceType,
@@ -342,7 +343,7 @@ export type MuteQueryModelInstance = Instance<typeof MuteQueryModel>;
 export interface IMuteQueryModel extends IQueryMeta {
   // Views
   readonly rootModel: Record<string, unknown>;
-  readonly contentModel: Record<string, unknown>;
+  readonly contentModel: IContentRenderModel;
   readonly conditionOptions: {
     optionGroups: Array<ComboboxItemGroup<ComboboxItem>>;
     validValues: Set<string>;

--- a/dashboard/src/model/render-model/dashboard/content/queries/queries.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/queries.ts
@@ -224,7 +224,7 @@ export interface IQueriesRenderModel {
   // Views
   readonly idSet: Set<string>;
   readonly firstID: string | undefined;
-  readonly json: Array<IQueryRenderModel>;
+  readonly json: Array<IQueryRenderModel['json']>;
   readonly root: Record<string, unknown>;
   readonly dashboardName: string;
   readonly contentModel: Record<string, unknown>;
@@ -242,10 +242,10 @@ export interface IQueriesRenderModel {
   downloadAllData(): void;
   downloadDataByQueryIDs(filename: string, ids: string[]): void;
   downloadDataByQueryID(filename: string | null, id: string): void;
-  refetchDataByQueryID(queryID: string): Promise<void>;
+  refetchDataByQueryID(queryID: string): Promise<void> | void;
   getSchema(ids: string[]): {
     definition: {
-      queries: Array<IQueryRenderModel>;
+      queries: Array<IQueryRenderModel['json']>;
     };
     version: string;
   };
@@ -254,3 +254,4 @@ export interface IQueriesRenderModel {
 }
 
 typeAssert.shouldExtends<IQueriesRenderModel, QueriesRenderModelInstance>();
+typeAssert.shouldExtends<QueriesRenderModelInstance, IQueriesRenderModel>();

--- a/dashboard/src/model/render-model/dashboard/content/queries/queries.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/queries.ts
@@ -1,9 +1,11 @@
 import _ from 'lodash';
 import { Instance, SnapshotIn, flow, getParent, getRoot, types } from 'mobx-state-tree';
+import { IObservableArray } from 'mobx';
 import { CURRENT_SCHEMA_VERSION, QueryMetaSnapshotIn } from '~/model/meta-model';
 import { downloadDataAsCSV, downloadDataListAsZip, downloadJSON } from '~/utils/download';
-import { QueryRenderModel, QueryRenderModelInstance } from './query';
+import { QueryRenderModel, QueryRenderModelInstance, type IQueryRenderModel } from './query';
 import { TransformQueryMetaInstance } from '~/model/meta-model/dashboard/content/query/transform-query';
+import { typeAssert } from '~/types/utils';
 
 export const QueriesRenderModel = types
   .model('QueriesRenderModel', {
@@ -214,3 +216,41 @@ export function getInitialQueriesRenderModel(queries: QueryMetaSnapshotIn[]): Qu
     current: queries,
   };
 }
+
+export interface IQueriesRenderModel {
+  // Properties
+  current: IObservableArray<IQueryRenderModel>;
+
+  // Views
+  readonly idSet: Set<string>;
+  readonly firstID: string | undefined;
+  readonly json: Array<IQueryRenderModel>;
+  readonly root: Record<string, unknown>;
+  readonly dashboardName: string;
+  readonly contentModel: Record<string, unknown>;
+  readonly visibleQueryIDSet: Set<string>;
+  readonly querisToForceReload: {
+    filterQueries: IQueryRenderModel[];
+    panelQueries: IQueryRenderModel[];
+  };
+
+  // Methods
+  findByID(id: string): IQueryRenderModel | undefined;
+  findByIDSet(idset: Set<string>): IQueryRenderModel[];
+  isQueryInUse(queryID: string): boolean;
+  addTransformDepQueryIDs(targetSet: Set<string>, excludeSet?: Set<string>): void;
+  downloadAllData(): void;
+  downloadDataByQueryIDs(filename: string, ids: string[]): void;
+  downloadDataByQueryID(filename: string | null, id: string): void;
+  refetchDataByQueryID(queryID: string): Promise<void>;
+  getSchema(ids: string[]): {
+    definition: {
+      queries: Array<IQueryRenderModel>;
+    };
+    version: string;
+  };
+  downloadSchema(ids: string[]): void;
+  forceReloadVisibleQueries(): Promise<void>;
+}
+
+typeAssert.shouldExtends<IQueriesRenderModel, QueriesRenderModelInstance>();

--- a/dashboard/src/model/render-model/dashboard/content/queries/queries.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/queries.ts
@@ -3,6 +3,7 @@ import { Instance, SnapshotIn, flow, getParent, getRoot, types } from 'mobx-stat
 import { IObservableArray } from 'mobx';
 import { CURRENT_SCHEMA_VERSION, QueryMetaSnapshotIn } from '~/model/meta-model';
 import { downloadDataAsCSV, downloadDataListAsZip, downloadJSON } from '~/utils/download';
+import { IContentRenderModel } from '../../../../../dashboard-render';
 import { QueryRenderModel, QueryRenderModelInstance, type IQueryRenderModel } from './query';
 import { TransformQueryMetaInstance } from '~/model/meta-model/dashboard/content/query/transform-query';
 import { typeAssert } from '~/types/utils';
@@ -227,7 +228,7 @@ export interface IQueriesRenderModel {
   readonly json: Array<IQueryRenderModel['json']>;
   readonly root: Record<string, unknown>;
   readonly dashboardName: string;
-  readonly contentModel: Record<string, unknown>;
+  readonly contentModel: IContentRenderModel;
   readonly visibleQueryIDSet: Set<string>;
   readonly querisToForceReload: {
     filterQueries: IQueryRenderModel[];

--- a/dashboard/src/model/render-model/dashboard/content/queries/query.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/query.ts
@@ -8,7 +8,8 @@ import { DBQueryMetaInstance } from '~/model/meta-model/dashboard/content/query/
 import { TransformQueryMetaInstance } from '~/model/meta-model/dashboard/content/query/transform-query';
 import { AnyObject } from '~/types';
 import { functionUtils, postProcessWithDataSource, postProcessWithQuery, preProcessWithDataSource } from '~/utils';
-import { MuteQueryModel } from './mute-query';
+import { MuteQueryModel, type IMuteQueryModel } from './mute-query';
+import { typeAssert } from '~/types/utils';
 
 enum QueryState {
   idle = 'idle',
@@ -326,6 +327,33 @@ export const QueryRenderModel = types
 
 export type QueryRenderModelInstance = Instance<typeof QueryRenderModel>;
 export type QueryRenderModelSnapshotIn = SnapshotIn<QueryRenderModelInstance>;
+
+export interface IQueryRenderModel extends IMuteQueryModel {
+  // Properties
+  state: QueryState;
+  data: string[][] | number[][] | AnyObject[];
+  error: QueryFailureError | null;
+  controller: AbortController;
+
+  // Views
+  readonly datasource: Record<string, unknown> | undefined;
+  readonly additionalQueryInfo: TAdditionalQueryInfo;
+  readonly depQueryModels: IQueryRenderModel[];
+  readonly depQueryModelStates: QueryState[];
+  readonly depQueryModelStatesString: string;
+  readonly stateMessage: string;
+
+  // Actions
+  runSQL(): Promise<void>;
+  runHTTP(): Promise<void>;
+  runMericoMetricQuery(): Promise<void>;
+  runTransformation(): Promise<void>;
+  fetchData(force: boolean): Promise<void>;
+  beforeDestroy(): void;
+  afterCreate(): void;
+}
+
+typeAssert.shouldExtends<IQueryRenderModel, QueryRenderModelInstance>();
 
 export type QueryUsageType =
   | {

--- a/dashboard/src/model/render-model/dashboard/content/queries/query.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/query.ts
@@ -10,6 +10,8 @@ import { AnyObject } from '~/types';
 import { functionUtils, postProcessWithDataSource, postProcessWithQuery, preProcessWithDataSource } from '~/utils';
 import { MuteQueryModel, type IMuteQueryModel } from './mute-query';
 import { typeAssert } from '~/types/utils';
+import { DataSourceMetaModelInstance } from '~/model/meta-model';
+import { DataSourceModelInstance } from '~/dashboard-editor/model/datasources/datasource';
 
 type QueryStateType = 'idle' | 'loading' | 'error';
 
@@ -20,7 +22,7 @@ export const QueryRenderModel = types
     types.model({
       state: types.optional(types.enumeration<QueryStateType>(['idle', 'loading', 'error']), 'idle'),
       data: types.optional(types.frozen<string[][] | number[][] | AnyObject[]>([]), []),
-      error: types.frozen(),
+      error: types.optional(types.frozen<string | null>(), null),
     }),
   )
   .views((self) => ({
@@ -122,7 +124,7 @@ export const QueryRenderModel = types
           if (!axios.isCancel(error)) {
             self.data = [];
             const fallback = get(error, 'message', 'unkown error');
-            self.error = get(error, 'response.data.detail.message', fallback) as unknown as QueryFailureError;
+            self.error = get(error, 'response.data.detail.message', fallback) as unknown as string | null;
             self.state = 'error';
           } else {
             console.debug(`🟡 Query[${self.name}] is cancelled`);
@@ -170,7 +172,7 @@ export const QueryRenderModel = types
           if (!axios.isCancel(error)) {
             self.data = [];
             const fallback = get(error, 'message', 'unkown error');
-            self.error = get(error, 'response.data.detail.message', fallback) as unknown as QueryFailureError;
+            self.error = get(error, 'response.data.detail.message', fallback) as unknown as string | null;
             self.state = 'error';
           } else {
             console.debug(`🟡 Query[${self.name}] is cancelled`);
@@ -223,7 +225,7 @@ export const QueryRenderModel = types
           if (!axios.isCancel(error)) {
             self.data = [];
             const fallback = get(error, 'message', 'unkown error');
-            self.error = get(error, 'response.data.detail.message', fallback) as unknown as QueryFailureError;
+            self.error = get(error, 'response.data.detail.message', fallback) as unknown as string | null;
             self.state = 'error';
           } else {
             console.debug(`🟡 Query[${self.name}] is cancelled`);
@@ -324,16 +326,16 @@ export const QueryRenderModel = types
 export type QueryRenderModelInstance = Instance<typeof QueryRenderModel>;
 export type QueryRenderModelSnapshotIn = SnapshotIn<QueryRenderModelInstance>;
 
-export type IQueryRenderModelData = string[][] | number[][] | AnyObject[];
 export interface IQueryRenderModel extends IMuteQueryModel {
   // Properties
   state: QueryStateType;
-  data: IQueryRenderModelData;
-  error: QueryFailureError | null;
+  data: TQueryData;
+  error: string | null;
   controller: AbortController;
 
   // Views
-  readonly datasource: Record<string, unknown> | undefined;
+  readonly datasource: DataSourceMetaModelInstance | DataSourceModelInstance | undefined;
+
   readonly additionalQueryInfo: TAdditionalQueryInfo;
   readonly depQueryModels: IQueryRenderModel[];
   readonly depQueryModelStates: QueryStateType[];
@@ -348,6 +350,8 @@ export interface IQueryRenderModel extends IMuteQueryModel {
   fetchData(force: boolean): Promise<void> | void;
   beforeDestroy(): void;
   afterCreate(): void;
+  setData(data: TQueryData): void;
+  setError(error: string | null): void;
 }
 
 typeAssert.shouldExtends<IQueryRenderModel, QueryRenderModelInstance>();

--- a/dashboard/src/model/render-model/dashboard/content/queries/query.ts
+++ b/dashboard/src/model/render-model/dashboard/content/queries/query.ts
@@ -11,18 +11,14 @@ import { functionUtils, postProcessWithDataSource, postProcessWithQuery, preProc
 import { MuteQueryModel, type IMuteQueryModel } from './mute-query';
 import { typeAssert } from '~/types/utils';
 
-enum QueryState {
-  idle = 'idle',
-  loading = 'loading',
-  error = 'error',
-}
+type QueryStateType = 'idle' | 'loading' | 'error';
 
 export const QueryRenderModel = types
   .compose(
     'QueryRenderModel',
     MuteQueryModel,
     types.model({
-      state: types.optional(types.enumeration(['idle', 'loading', 'error']), 'idle'),
+      state: types.optional(types.enumeration<QueryStateType>(['idle', 'loading', 'error']), 'idle'),
       data: types.optional(types.frozen<string[][] | number[][] | AnyObject[]>([]), []),
       error: types.frozen(),
     }),
@@ -41,7 +37,7 @@ export const QueryRenderModel = types
     },
     get depQueryModelStates() {
       // NOTE(leto): can't use QueryRenderModelInstance. 'QueryRenderModel' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.ts(7022)
-      return this.depQueryModels.map((q: any) => q.state as QueryState);
+      return this.depQueryModels.map((q: any) => q.state as QueryStateType);
     },
     get depQueryModelStatesString() {
       return this.depQueryModelStates.toString();
@@ -328,10 +324,11 @@ export const QueryRenderModel = types
 export type QueryRenderModelInstance = Instance<typeof QueryRenderModel>;
 export type QueryRenderModelSnapshotIn = SnapshotIn<QueryRenderModelInstance>;
 
+export type IQueryRenderModelData = string[][] | number[][] | AnyObject[];
 export interface IQueryRenderModel extends IMuteQueryModel {
   // Properties
-  state: QueryState;
-  data: string[][] | number[][] | AnyObject[];
+  state: QueryStateType;
+  data: IQueryRenderModelData;
   error: QueryFailureError | null;
   controller: AbortController;
 
@@ -339,7 +336,7 @@ export interface IQueryRenderModel extends IMuteQueryModel {
   readonly datasource: Record<string, unknown> | undefined;
   readonly additionalQueryInfo: TAdditionalQueryInfo;
   readonly depQueryModels: IQueryRenderModel[];
-  readonly depQueryModelStates: QueryState[];
+  readonly depQueryModelStates: QueryStateType[];
   readonly depQueryModelStatesString: string;
   readonly stateMessage: string;
 
@@ -347,13 +344,14 @@ export interface IQueryRenderModel extends IMuteQueryModel {
   runSQL(): Promise<void>;
   runHTTP(): Promise<void>;
   runMericoMetricQuery(): Promise<void>;
-  runTransformation(): Promise<void>;
-  fetchData(force: boolean): Promise<void>;
+  runTransformation(): void;
+  fetchData(force: boolean): Promise<void> | void;
   beforeDestroy(): void;
   afterCreate(): void;
 }
 
 typeAssert.shouldExtends<IQueryRenderModel, QueryRenderModelInstance>();
+typeAssert.shouldExtends<QueryRenderModelInstance, IQueryRenderModel>();
 
 export type QueryUsageType =
   | {

--- a/dashboard/src/model/render-model/dashboard/content/sql-snippets/sql-snippet.ts
+++ b/dashboard/src/model/render-model/dashboard/content/sql-snippets/sql-snippet.ts
@@ -1,6 +1,7 @@
 import { getParent, Instance, SnapshotIn } from 'mobx-state-tree';
-import { SQLSnippetMeta } from '~/model';
+import { SQLSnippetMeta, type ISQLSnippetMeta } from '~/model';
 import { SQLSnippetsRenderModelInstance } from './types';
+import { typeAssert } from '~/types/utils';
 
 export const SQLSnippetRenderModel = SQLSnippetMeta.views((self) => ({
   isADuplicatedKey(newKey: string) {
@@ -21,5 +22,11 @@ export const SQLSnippetRenderModel = SQLSnippetMeta.views((self) => ({
 
 export type SQLSnippetRenderModelInstance = Instance<typeof SQLSnippetRenderModel>;
 export type SQLSnippetRenderModelSnapshotIn = SnapshotIn<SQLSnippetRenderModelInstance>;
+
+export interface ISQLSnippetRenderModel extends ISQLSnippetMeta {
+  isADuplicatedKey(newKey: string): boolean;
+}
+
+typeAssert.shouldExtends<ISQLSnippetRenderModel, SQLSnippetRenderModelInstance>();
 
 export type SQLSnippetUsageType = { queryID: string; sqlSnippetKey: string; queryName: string };

--- a/dashboard/src/model/render-model/dashboard/content/sql-snippets/sql-snippets.ts
+++ b/dashboard/src/model/render-model/dashboard/content/sql-snippets/sql-snippets.ts
@@ -1,7 +1,9 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
+import { IObservableArray } from 'mobx';
 import { CURRENT_SCHEMA_VERSION, SQLSnippetMetaSnapshotIn } from '~/model';
 import { downloadJSON } from '~/utils/download';
-import { SQLSnippetRenderModel } from './sql-snippet';
+import { SQLSnippetRenderModel, type ISQLSnippetRenderModel } from './sql-snippet';
+import { typeAssert } from '~/types/utils';
 
 export const SQLSnippetsRenderModel = types
   .model('SQLSnippetsRenderModel', {
@@ -54,6 +56,30 @@ export const SQLSnippetsRenderModel = types
   }));
 
 export type SQLSnippetsRenderModelSnapshotIn = SnapshotIn<Instance<typeof SQLSnippetsRenderModel>>;
+
+export interface ISQLSnippetsRenderModel {
+  // Properties
+  current: IObservableArray<ISQLSnippetRenderModel>;
+
+  // Views
+  readonly json: Array<ISQLSnippetRenderModel['json']>;
+  readonly record: Record<string, string>;
+  readonly keySet: Set<string>;
+  readonly firstKey: string | undefined;
+
+  // Methods
+  findByKey(key: string): ISQLSnippetRenderModel | undefined;
+  findByKeySet(keySet: Set<string>): ISQLSnippetRenderModel[];
+  getSchema(keys: string[]): {
+    definition: {
+      sqlSnippets: Array<ISQLSnippetRenderModel['json']>;
+    };
+    version: string;
+  };
+  downloadSchema(keys: string[]): void;
+}
+
+typeAssert.shouldExtends<ISQLSnippetsRenderModel, Instance<typeof SQLSnippetsRenderModel>>();
 
 export function getInitialSQLSnippetsRenderModel(
   snippets: SQLSnippetMetaSnapshotIn[],

--- a/dashboard/src/model/render-model/dashboard/content/views/view.ts
+++ b/dashboard/src/model/render-model/dashboard/content/views/view.ts
@@ -1,12 +1,24 @@
-import { reaction } from 'mobx';
+import { reaction, type IObservableArray } from 'mobx';
 import { saveAs } from 'file-saver';
 import { addDisposer, getParent, getRoot, Instance, types } from 'mobx-state-tree';
-import { EViewComponentType, TabInfo, TabModelInstance, ViewMeta, ViewTabsConfigInstance } from '~/model/meta-model';
+import {
+  EViewComponentType,
+  TabInfo,
+  TabModelInstance,
+  ViewMeta,
+  ViewTabsConfigInstance,
+  type ITabModel,
+  type IViewMeta,
+} from '~/model/meta-model';
 // @ts-expect-error dom-to-image-more's declaration file
 import domtoimage from 'dom-to-image-more';
 import JSZip from 'jszip';
 import { notifications } from '@mantine/notifications';
 import _ from 'lodash';
+import { typeAssert } from '~/types/utils';
+import { ViewsRenderModel } from './views';
+
+type ViewsRenderModelInstance = Instance<typeof ViewsRenderModel>;
 
 export const ViewRenderModel = types
   .compose(
@@ -105,3 +117,25 @@ export const ViewRenderModel = types
   }));
 
 export type ViewRenderModelInstance = Instance<typeof ViewRenderModel>;
+
+export interface IViewRenderModel extends IViewMeta {
+  // Properties
+  tab: string;
+
+  // Views
+  readonly tabs: IObservableArray<ITabModel>;
+  readonly tabInfo: TabInfo | null;
+  readonly tabView: ITabModel | null | undefined;
+  readonly tabViewID: string;
+  readonly contentModel: any; // todo: fix type
+  readonly panels: IObservableArray<any>;
+  readonly renderViewIDs: string[];
+
+  // Methods
+  setTab(tab: string | null): void;
+  setTabByTabInfo(tabInfo: TabInfo): void;
+  downloadScreenshot(dom: HTMLElement): Promise<void>;
+}
+
+typeAssert.shouldExtends<IViewRenderModel, Instance<typeof ViewRenderModel>>();
+typeAssert.shouldExtends<Instance<typeof ViewRenderModel>, IViewRenderModel>();

--- a/dashboard/src/model/render-model/dashboard/content/views/view.ts
+++ b/dashboard/src/model/render-model/dashboard/content/views/view.ts
@@ -1,24 +1,21 @@
-import { reaction, type IObservableArray } from 'mobx';
-import { saveAs } from 'file-saver';
-import { addDisposer, getParent, getRoot, Instance, types } from 'mobx-state-tree';
-import {
-  EViewComponentType,
-  TabInfo,
-  TabModelInstance,
-  ViewMeta,
-  ViewTabsConfigInstance,
-  type ITabModel,
-  type IViewMeta,
-} from '~/model/meta-model';
+import { notifications } from '@mantine/notifications';
 // @ts-expect-error dom-to-image-more's declaration file
 import domtoimage from 'dom-to-image-more';
+import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
-import { notifications } from '@mantine/notifications';
-import _ from 'lodash';
+import { type IObservableArray } from 'mobx';
+import { getParent, Instance, types } from 'mobx-state-tree';
+import {
+  EViewComponentType,
+  type ITabModel,
+  type IViewMeta,
+  TabInfo,
+  ViewMeta,
+  ViewTabsConfigInstance,
+} from '~/model/meta-model';
 import { typeAssert } from '~/types/utils';
-import { ViewsRenderModel } from './views';
-
-type ViewsRenderModelInstance = Instance<typeof ViewsRenderModel>;
+import { IContentRenderModel } from '../../../../../dashboard-render';
+import { IPanelRenderModel } from '../panels';
 
 export const ViewRenderModel = types
   .compose(
@@ -57,7 +54,7 @@ export const ViewRenderModel = types
 
       return this.tabView.view_id ?? '';
     },
-    get contentModel() {
+    get contentModel(): IContentRenderModel {
       // FIXME: type
       return getParent(self, 3) as any;
     },
@@ -127,13 +124,15 @@ export interface IViewRenderModel extends IViewMeta {
   readonly tabInfo: TabInfo | null;
   readonly tabView: ITabModel | null | undefined;
   readonly tabViewID: string;
-  readonly contentModel: any; // todo: fix type
-  readonly panels: IObservableArray<any>;
+  readonly contentModel: IContentRenderModel;
+  readonly panels: IPanelRenderModel[];
   readonly renderViewIDs: string[];
 
   // Methods
   setTab(tab: string | null): void;
+
   setTabByTabInfo(tabInfo: TabInfo): void;
+
   downloadScreenshot(dom: HTMLElement): Promise<void>;
 }
 

--- a/dashboard/src/model/render-model/dashboard/content/views/views.ts
+++ b/dashboard/src/model/render-model/dashboard/content/views/views.ts
@@ -1,9 +1,20 @@
 import { Instance, SnapshotIn, types } from 'mobx-state-tree';
+import { type IObservableArray } from 'mobx';
 import { IDashboardView } from '~/types';
+import { TabsVariant } from '@mantine/core';
 
-import { EViewComponentType, TabInfo, TabModelInstance, ViewMetaInstance, ViewRenderModel } from '~/model';
+import {
+  EViewComponentType,
+  TabInfo,
+  TabModelInstance,
+  ViewMetaInstance,
+  ViewRenderModel,
+  type IViewRenderModel,
+} from '~/model';
+import { TabsOrientation, type IViewMeta } from '~/model/meta-model';
 import { shallowToJS } from '~/utils';
 import _ from 'lodash';
+import { typeAssert } from '~/types/utils';
 
 export const ViewsRenderModel = types
   .model('ViewsRenderModel', {
@@ -71,6 +82,30 @@ export const ViewsRenderModel = types
   }));
 
 export type ViewsRenderModelInstance = Instance<typeof ViewsRenderModel>;
+
+export interface IViewsRenderModel {
+  // Properties
+  current: IObservableArray<IViewRenderModel>;
+  visibleViewIDs: IObservableArray<string>;
+
+  // Views
+  readonly json: Array<IViewRenderModel['json']>;
+  readonly idMap: Map<string, IViewMeta>;
+  readonly firstVisibleView: IViewRenderModel | undefined;
+  readonly visibleViews: IViewRenderModel[];
+  readonly firstVisibleTabsView: IViewRenderModel | undefined;
+  readonly firstVisibleTabsViewActiveTab: TabInfo | null;
+  readonly firstVisibleTabsViewActiveTabStr: string;
+
+  // Methods
+  findByID(id: string): IViewRenderModel | undefined;
+  appendToVisibles(viewID: string): void;
+  rmVisibleViewID(id: string): void;
+  setFirstVisibleTabsViewActiveTab(tabInfo: TabInfo | null): void;
+}
+
+typeAssert.shouldExtends<IViewsRenderModel, Instance<typeof ViewsRenderModel>>();
+typeAssert.shouldExtends<Instance<typeof ViewsRenderModel>, IViewsRenderModel>();
 
 export function getInitialViewsRenderModel(
   views: IDashboardView[],

--- a/dashboard/src/types/exported-models.ts
+++ b/dashboard/src/types/exported-models.ts
@@ -1,0 +1,8 @@
+// TypeScript interfaces for exported models
+
+import type { DashboardFilterType } from "./filter";
+import type { FilterSelectConfigInstance } from "~/model";
+
+
+
+

--- a/dashboard/src/types/exported-models.ts
+++ b/dashboard/src/types/exported-models.ts
@@ -1,8 +1,0 @@
-// TypeScript interfaces for exported models
-
-import type { DashboardFilterType } from "./filter";
-import type { FilterSelectConfigInstance } from "~/model";
-
-
-
-

--- a/dashboard/src/types/utils.ts
+++ b/dashboard/src/types/utils.ts
@@ -1,2 +1,7 @@
 export type AnyObject = Record<string, $TSFixMe>;
 export type Ready<T, TK extends keyof T> = T & { [P in TK]-?: NonNullable<T[P]> };
+
+export const typeAssert = {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  shouldExtends<TImpl extends T, T>(): void {},
+};


### PR DESCRIPTION
由于部分 mst 模型的类型定义过于复杂，导致 tsc 拒绝为其生成 .d.ts 文件，在这个 MR 中借助 LLM 为 render 模式下会使用到的模型生成了合适的 .d.ts 定义。

后续可以借助下面的 Prompt 完善 editor 模式下的类型。
```
complete the interface without using types from mst. If the array type does not match, try to use IObservableArray<T>. The referenced model type have their corresponding IXXX interfaces, use  these interface types when possible
```

![image](https://github.com/user-attachments/assets/baf0773c-beeb-459d-9142-8585172c1d76)
