### PR TITLE
fix(dashboard): update date range shortcuts to end at day's end

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devtable/api",
-  "version": "14.50.2",
+  "version": "14.50.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devtable/dashboard",
-  "version": "14.50.2",
+  "version": "14.50.3",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",

--- a/dashboard/src/components/filter/filter-date-range/widget/shortcuts/shortcuts.test.ts
+++ b/dashboard/src/components/filter/filter-date-range/widget/shortcuts/shortcuts.test.ts
@@ -1,0 +1,38 @@
+import dayjs from 'dayjs';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getDateRangeShortcuts } from './shortcuts';
+
+describe('getDateRangeShortcuts', () => {
+  beforeAll(() => {
+    // Mock Date.now() to ensure consistent test results
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-08-06T10:00:00Z'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  describe('getRange function', () => {
+    it('should have end date at the end of the day for all shortcuts', () => {
+      const shortcuts = getDateRangeShortcuts();
+
+      // Test ALL shortcuts to ensure consistency
+      shortcuts.forEach((shortcut) => {
+        const range = shortcut.getRange();
+        const endDate = range.value[1];
+
+        // Verify endDate is not null
+        expect(endDate, `Shortcut "${shortcut.value}" should have a valid end date`).not.toBeNull();
+
+        // Verify the end date is at the end of the day (23:59:59.xxx)
+        if (endDate) {
+          const endOfDay = dayjs(endDate).endOf('day');
+          expect(endDate.getTime(), `Shortcut "${shortcut.value}" should have end date at the end of the day`).toBe(
+            endOfDay.toDate().getTime(),
+          );
+        }
+      });
+    });
+  });
+});

--- a/dashboard/src/components/filter/filter-date-range/widget/shortcuts/shortcuts.ts
+++ b/dashboard/src/components/filter/filter-date-range/widget/shortcuts/shortcuts.ts
@@ -16,12 +16,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'yesterday',
     group: 'last',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(1, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(1, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'yesterday',
       };
     },
@@ -31,12 +28,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'last week',
     group: 'last',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(1, 'week').startOf('week').toDate(),
-          dayjs(now).subtract(1, 'week').endOf('week').toDate(),
-        ],
+        value: [now.subtract(1, 'week').startOf('week').toDate(), now.subtract(1, 'week').endOf('week').toDate()],
         shortcut: 'last week',
       };
     },
@@ -46,12 +40,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'last month',
     group: 'last',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(1, 'month').startOf('month').toDate(),
-          dayjs(now).subtract(1, 'month').endOf('month').toDate(),
-        ],
+        value: [now.subtract(1, 'month').startOf('month').toDate(), now.subtract(1, 'month').endOf('month').toDate()],
         shortcut: 'last month',
       };
     },
@@ -61,12 +52,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'last 2 months',
     group: 'last',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(2, 'month').startOf('month').toDate(),
-          dayjs(now).subtract(1, 'month').endOf('month').toDate(),
-        ],
+        value: [now.subtract(2, 'month').startOf('month').toDate(), now.subtract(1, 'month').endOf('month').toDate()],
         shortcut: 'last 2 months',
       };
     },
@@ -76,12 +64,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'last 3 months',
     group: 'last',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(3, 'month').startOf('month').toDate(),
-          dayjs(now).subtract(1, 'month').endOf('month').toDate(),
-        ],
+        value: [now.subtract(3, 'month').startOf('month').toDate(), now.subtract(1, 'month').endOf('month').toDate()],
         shortcut: 'last 3 months',
       };
     },
@@ -91,12 +76,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'last year',
     group: 'last',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(1, 'year').startOf('year').toDate(),
-          dayjs(now).subtract(1, 'year').endOf('year').toDate(),
-        ],
+        value: [now.subtract(1, 'year').startOf('year').toDate(), now.subtract(1, 'year').endOf('year').toDate()],
         shortcut: 'last year',
       };
     },
@@ -106,12 +88,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'recent 7 days',
     group: 'recent',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(7, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(7, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'recent 7 days',
       };
     },
@@ -121,12 +100,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'recent 30 days',
     group: 'recent',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(30, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(30, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'recent 30 days',
       };
     },
@@ -136,12 +112,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'recent 60 days',
     group: 'recent',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(60, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(60, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'recent 60 days',
       };
     },
@@ -151,12 +124,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'recent 90 days',
     group: 'recent',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(90, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(90, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'recent 90 days',
       };
     },
@@ -166,12 +136,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'recent 180 days',
     group: 'recent',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(180, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(180, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'recent 180 days',
       };
     },
@@ -181,12 +148,9 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'recent 365 days',
     group: 'recent',
     getRange: () => {
-      const now = Date.now();
+      const now = dayjs();
       return {
-        value: [
-          dayjs(now).subtract(365, 'day').startOf('day').toDate(),
-          dayjs(now).subtract(1, 'day').endOf('day').toDate(),
-        ],
+        value: [now.subtract(365, 'day').startOf('day').toDate(), now.subtract(1, 'day').endOf('day').toDate()],
         shortcut: 'recent 365 days',
       };
     },
@@ -196,8 +160,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'today',
     group: 'this',
     getRange: () => {
-      const now = Date.now();
-      return { value: [dayjs(now).startOf('day').toDate(), dayjs(now).endOf('day').toDate()], shortcut: 'today' };
+      const now = dayjs();
+      return { value: [now.startOf('day').toDate(), now.endOf('day').toDate()], shortcut: 'today' };
     },
   },
   {
@@ -205,8 +169,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'this week',
     group: 'this',
     getRange: () => {
-      const now = Date.now();
-      return { value: [dayjs(now).startOf('week').toDate(), dayjs(now).endOf('week').toDate()], shortcut: 'this week' };
+      const now = dayjs();
+      return { value: [now.startOf('week').toDate(), now.endOf('week').toDate()], shortcut: 'this week' };
     },
   },
   {
@@ -214,11 +178,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'this month',
     group: 'this',
     getRange: () => {
-      const now = Date.now();
-      return {
-        value: [dayjs(now).startOf('month').toDate(), dayjs(now).endOf('month').toDate()],
-        shortcut: 'this month',
-      };
+      const now = dayjs();
+      return { value: [now.startOf('month').toDate(), now.endOf('month').toDate()], shortcut: 'this month' };
     },
   },
   {
@@ -226,8 +187,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'this year',
     group: 'this',
     getRange: () => {
-      const now = Date.now();
-      return { value: [dayjs(now).startOf('year').toDate(), dayjs(now).endOf('year').toDate()], shortcut: 'this year' };
+      const now = dayjs();
+      return { value: [now.startOf('year').toDate(), now.endOf('year').toDate()], shortcut: 'this year' };
     },
   },
   {
@@ -235,11 +196,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'this week so far',
     group: 'this_so_far',
     getRange: () => {
-      const now = Date.now();
-      return {
-        value: [dayjs(now).startOf('week').toDate(), dayjs(now).endOf('day').toDate()],
-        shortcut: 'this week so far',
-      };
+      const now = dayjs();
+      return { value: [now.startOf('week').toDate(), now.endOf('day').toDate()], shortcut: 'this week so far' };
     },
   },
   {
@@ -247,11 +205,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'this month so far',
     group: 'this_so_far',
     getRange: () => {
-      const now = Date.now();
-      return {
-        value: [dayjs(now).startOf('month').toDate(), dayjs(now).endOf('day').toDate()],
-        shortcut: 'this month so far',
-      };
+      const now = dayjs();
+      return { value: [now.startOf('month').toDate(), now.endOf('day').toDate()], shortcut: 'this month so far' };
     },
   },
   {
@@ -259,11 +214,8 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     value: 'this year so far',
     group: 'this_so_far',
     getRange: () => {
-      const now = Date.now();
-      return {
-        value: [dayjs(now).startOf('year').toDate(), dayjs(now).endOf('day').toDate()],
-        shortcut: 'this year so far',
-      };
+      const now = dayjs();
+      return { value: [now.startOf('year').toDate(), now.endOf('day').toDate()], shortcut: 'this year so far' };
     },
   },
 ];

--- a/dashboard/src/components/filter/filter-date-range/widget/shortcuts/shortcuts.ts
+++ b/dashboard/src/components/filter/filter-date-range/widget/shortcuts/shortcuts.ts
@@ -236,7 +236,10 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     group: 'this_so_far',
     getRange: () => {
       const now = Date.now();
-      return { value: [dayjs(now).startOf('week').toDate(), dayjs(now).toDate()], shortcut: 'this week so far' };
+      return {
+        value: [dayjs(now).startOf('week').toDate(), dayjs(now).endOf('day').toDate()],
+        shortcut: 'this week so far',
+      };
     },
   },
   {
@@ -245,7 +248,10 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     group: 'this_so_far',
     getRange: () => {
       const now = Date.now();
-      return { value: [dayjs(now).startOf('month').toDate(), dayjs(now).toDate()], shortcut: 'this month so far' };
+      return {
+        value: [dayjs(now).startOf('month').toDate(), dayjs(now).endOf('day').toDate()],
+        shortcut: 'this month so far',
+      };
     },
   },
   {
@@ -254,7 +260,10 @@ export const getDateRangeShortcuts = (): Shrotcut[] => [
     group: 'this_so_far',
     getRange: () => {
       const now = Date.now();
-      return { value: [dayjs(now).startOf('year').toDate(), dayjs(now).toDate()], shortcut: 'this year so far' };
+      return {
+        value: [dayjs(now).startOf('year').toDate(), dayjs(now).endOf('day').toDate()],
+        shortcut: 'this year so far',
+      };
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devtable/root",
-  "version": "14.50.2",
+  "version": "14.50.3",
   "private": true,
   "workspaces": [
     "api",

--- a/settings-form/package.json
+++ b/settings-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devtable/settings-form",
-  "version": "14.50.2",
+  "version": "14.50.3",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "name": "@devtable/website",
   "private": true,
   "license": "Apache-2.0",
-  "version": "14.50.2",
+  "version": "14.50.3",
   "scripts": {
     "dev": "vite",
     "preview": "vite preview"


### PR DESCRIPTION
部分 shortbut.getRange().value[1] 会返回当前时刻，而不是今天的结束时刻。导致同样的 shortcut 在不同的时间被转换成不同的 DateRange 从而引发重新渲染循环。

这个 PR 修复了这一问题，并加上了测试以固定这以行为。