### PR TITLE
fix(reference_areas): Set name from reference area data

### DIFF
--- a/dashboard/src/components/plugins/viz-components/cartesian/option/series/reference_areas.ts
+++ b/dashboard/src/components/plugins/viz-components/cartesian/option/series/reference_areas.ts
@@ -5,7 +5,7 @@ export function getReferenceAreas(
   variableValueMap: Record<string, string | number>,
 ) {
   return reference_areas.map((r) => ({
-    name: '',
+    name: r.name,
     type: 'line',
     hide_in_legend: true,
     data: [],


### PR DESCRIPTION
解决下拉菜单渲染回调提供的 echartsOptions 中无法区分参考区域数据的问题